### PR TITLE
30 movie index loop always creates a new movie

### DIFF
--- a/pkg/library/library.go
+++ b/pkg/library/library.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,7 +36,9 @@ func New(movies FileSystem, tv FileSystem, io io.FileIO) Library {
 	}
 }
 
-// AddMovie adds a movie file from an absolute path to the movie library. If a directory does not exist for the movie, it will be created using the title provided.
+// AddMovie adds a movie file from an absolute path to the movie library.
+// If a directory does not exist for the movie, it will be created using the title provided.
+// This assumes the source path is not already relative to the library, i.e it was downloaded or discoverd outside of the library.
 // TODO: add option to delete source file if we succesfully copy
 func (l *MediaLibrary) AddMovie(ctx context.Context, title, sourcePath string) (MovieFile, error) {
 	log := logger.FromCtx(ctx)
@@ -214,16 +215,4 @@ func dirName(path string) string {
 	dirPath := filepath.Dir(path)
 	split := strings.Split(dirPath, string(os.PathSeparator))
 	return split[len(split)-1]
-}
-
-func fileSizeToString(size int64) string {
-	const unit = 1024
-
-	if size < unit {
-		return fmt.Sprintf("%d B", size)
-	}
-
-	exp := int(math.Log(float64(size)) / math.Log(unit))
-	pre := "KMGTPE"[exp-1]
-	return fmt.Sprintf("%.1f %cB", float64(size)/math.Pow(unit, float64(exp)), pre)
 }

--- a/pkg/library/library_test.go
+++ b/pkg/library/library_test.go
@@ -88,60 +88,6 @@ func TestFindEpisodes(t *testing.T) {
 	}
 }
 
-func Test_fileSizeToString(t *testing.T) {
-	type args struct {
-		size int64
-	}
-	tests := []struct {
-		name string
-		want string
-		args args
-	}{
-		{
-			name: "b",
-			args: args{size: 500},
-			want: "500 B",
-		},
-		{
-			name: "kb",
-			args: args{size: 1024},
-			want: "1.0 KB",
-		},
-		{
-			name: "mb",
-			args: args{size: 1048576}, // 1024 * 1024
-			want: "1.0 MB",
-		},
-		{
-			name: "gb",
-			args: args{size: 1073741824}, // 1024 * 1024 * 1024
-			want: "1.0 GB",
-		},
-		{
-			name: "tb",
-			args: args{size: 1099511627776}, // 1024^4
-			want: "1.0 TB",
-		},
-		{
-			name: "not whole number",
-			args: args{size: 123456789},
-			want: "117.7 MB",
-		},
-		{
-			name: "zero",
-			args: args{size: 0},
-			want: "0 B",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := fileSizeToString(tt.args.size); got != tt.want {
-				t.Errorf("fileSizeToString() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestMediaLibrary_AddMovie(t *testing.T) {
 	t.Run("error making directory", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/pkg/library/movie.go
+++ b/pkg/library/movie.go
@@ -13,7 +13,7 @@ type MovieFile struct {
 }
 
 func (mf MovieFile) String() string {
-	return fmt.Sprintf("name: %s, relative path: %s, size: %s", mf.Name, mf.RelativePath, fileSizeToString(mf.Size))
+	return fmt.Sprintf("name: %s, relative path: %s, size in bytes: %d", mf.Name, mf.RelativePath, mf.Size)
 }
 
 func FromPath(path string) MovieFile {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -167,7 +167,7 @@ func (m MediaManager) ListMoviesInLibrary(ctx context.Context) ([]library.MovieF
 func (m MediaManager) Run(ctx context.Context) error {
 	log := logger.FromCtx(ctx)
 
-	movieIndexTicker := time.NewTicker(time.Second * 10)
+	movieIndexTicker := time.NewTicker(time.Minute * 10)
 	defer movieIndexTicker.Stop()
 	movieReconcileTicker := time.NewTicker(time.Minute * 10)
 	defer movieReconcileTicker.Stop()

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -307,55 +307,127 @@ func Test_Manager_reconcileUnreleasedMovie(t *testing.T) {
 }
 
 func TestIndexMovieLibrary(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	tmdbMock := mocks.NewMockClientInterface(ctrl)
-	prowlarrMock := prowlMock.NewMockClientInterface(ctrl)
-	store, err := sqlite.New(":memory:")
-	require.Nil(t, err)
+	t.Run("error listing finding files in library", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
 
-	schemas, err := storage.ReadSchemaFiles("../storage/sqlite/schema/schema.sql")
-	require.Nil(t, err)
+		library := mockLibrary.NewMockLibrary(ctrl)
+		library.EXPECT().FindMovies(ctx).Times(1).Return(nil, errors.New("expected tested error"))
+		m := New(nil, nil, library, nil, nil)
+		require.NotNil(t, m)
 
-	ctx := context.Background()
-	err = store.Init(ctx, schemas...)
-	require.Nil(t, err)
+		err := m.IndexMovieLibrary(ctx)
+		assert.Error(t, err)
+		assert.EqualError(t, err, "failed to index movie library: expected tested error")
+	})
 
-	movieFS, expectedMovies := library.MovieFSFromFile(t, "../library/testing/test_movies.txt")
-	require.NotEmpty(t, expectedMovies)
-	tvFS, expectedEpisodes := library.TVFSFromFile(t, "../library/testing/test_episodes.txt")
-	require.NotEmpty(t, expectedEpisodes)
+	t.Run("no files discovered", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
 
-	lib := library.New(
-		library.FileSystem{
-			FS: movieFS,
-		},
-		library.FileSystem{
-			FS: tvFS,
-		},
-		&mio.MediaFileSystem{},
-	)
-	pClient, err := prowlarr.New(":", "1234")
-	pClient.ClientInterface = prowlarrMock
-	require.NoError(t, err)
+		mockLibrary := mockLibrary.NewMockLibrary(ctrl)
+		mockLibrary.EXPECT().FindMovies(ctx).Times(1).Return([]library.MovieFile{}, nil)
+		m := New(nil, nil, mockLibrary, nil, nil)
+		require.NotNil(t, m)
 
-	tClient, err := tmdb.New(":", "1234")
-	tClient.ClientInterface = tmdbMock
-	require.NoError(t, err)
+		err := m.IndexMovieLibrary(ctx)
+		assert.NoError(t, err)
+	})
 
-	mockFactory := downloadMock.NewMockFactory(ctrl)
-	m := New(tClient, pClient, lib, store, mockFactory)
-	require.NotNil(t, m)
+	t.Run("error listing movie files from storage", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
 
-	err = m.IndexMovieLibrary(ctx)
-	require.Nil(t, err)
+		store := newStore(t, ctx)
+		mockLibrary := mockLibrary.NewMockLibrary(ctrl)
 
-	mfs, err := store.ListMovieFiles(ctx)
-	assert.Nil(t, err)
-	assert.Len(t, mfs, len(expectedMovies))
+		discoveredFiles := []library.MovieFile{
+			{RelativePath: "movie1.mp4", AbsolutePath: "/movies/movie1.mp4"},
+		}
 
-	ms, err := store.ListMovies(ctx)
-	assert.Nil(t, err)
-	assert.Len(t, ms, len(expectedMovies))
+		mockLibrary.EXPECT().FindMovies(ctx).Times(1).Return(discoveredFiles, nil)
+
+		m := New(nil, nil, mockLibrary, store, nil)
+		require.NotNil(t, m)
+
+		err := m.IndexMovieLibrary(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("successfully indexes new movie files", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
+
+		store := newStore(t, ctx)
+		mockLibrary := mockLibrary.NewMockLibrary(ctrl)
+
+		discoveredFiles := []library.MovieFile{
+			{RelativePath: "movie1.mp4", AbsolutePath: "/movies/movie1.mp4", Size: 1024},
+			{RelativePath: "movie2.mkv", AbsolutePath: "/movies/movie2.mkv", Size: 2048},
+			{RelativePath: "movie3.txt", AbsolutePath: "/movies/movie3.txt", Size: 10},
+		}
+
+		mockLibrary.EXPECT().FindMovies(ctx).Times(1).Return(discoveredFiles, nil)
+
+		m := New(nil, nil, mockLibrary, store, nil)
+		require.NotNil(t, m)
+
+		err := m.IndexMovieLibrary(ctx)
+		assert.NoError(t, err)
+
+		movies, err := store.ListMovies(ctx)
+		require.NoError(t, err)
+		assert.Len(t, movies, 2)
+
+		movieFiles, err := store.ListMovieFiles(ctx)
+		require.NoError(t, err)
+		assert.Len(t, movieFiles, 2)
+
+		assert.Equal(t, "movie1.mp4", *movieFiles[0].RelativePath)
+		assert.Equal(t, int64(1024), movieFiles[0].Size)
+		assert.Equal(t, "movie2.mkv", *movieFiles[1].RelativePath)
+		assert.Equal(t, int64(2048), movieFiles[1].Size)
+	})
+
+	t.Run("skips already tracked files", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
+
+		store := newStore(t, ctx)
+		mockLibrary := mockLibrary.NewMockLibrary(ctrl)
+
+		existingMovie := storage.Movie{Movie: model.Movie{Path: ptr("movie1.mp4")}}
+		movieID, err := store.CreateMovie(ctx, existingMovie, storage.MovieStateDiscovered)
+		require.NoError(t, err)
+
+		_, err = store.CreateMovieFile(ctx, model.MovieFile{
+			MovieID:          int32(movieID),
+			RelativePath:     ptr("movie1.mp4"),
+			OriginalFilePath: ptr("/movies/movie1.mp4"),
+		})
+		require.NoError(t, err)
+
+		discoveredFiles := []library.MovieFile{
+			{RelativePath: "movie1.mp4", AbsolutePath: "/movies/movie1.mp4"},
+			{RelativePath: "movie2.mkv", AbsolutePath: "/movies/movie2.mkv"},
+		}
+
+		mockLibrary.EXPECT().FindMovies(ctx).Times(1).Return(discoveredFiles, nil)
+
+		m := New(nil, nil, mockLibrary, store, nil)
+		require.NotNil(t, m)
+
+		err = m.IndexMovieLibrary(ctx)
+		assert.NoError(t, err)
+
+		movies, err := store.ListMovies(ctx)
+		require.NoError(t, err)
+		assert.Len(t, movies, 2)
+
+		movieFiles, err := store.ListMovieFiles(ctx)
+		require.NoError(t, err)
+		assert.Len(t, movieFiles, 2)
+	})
 }
 
 func TestRun(t *testing.T) {

--- a/pkg/storage/mocks/mock_storage.go
+++ b/pkg/storage/mocks/mock_storage.go
@@ -319,19 +319,34 @@ func (mr *MockStorageMockRecorder) GetMovieByMetadataID(ctx, metadataID any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMovieByMetadataID", reflect.TypeOf((*MockStorage)(nil).GetMovieByMetadataID), ctx, metadataID)
 }
 
-// GetMovieFile mocks base method.
-func (m *MockStorage) GetMovieFile(ctx context.Context, id int64) (model.MovieFile, error) {
+// GetMovieByMovieFileID mocks base method.
+func (m *MockStorage) GetMovieByMovieFileID(ctx context.Context, fileID int64) (*storage.Movie, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMovieFile", ctx, id)
-	ret0, _ := ret[0].(model.MovieFile)
+	ret := m.ctrl.Call(m, "GetMovieByMovieFileID", ctx, fileID)
+	ret0, _ := ret[0].(*storage.Movie)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetMovieFile indicates an expected call of GetMovieFile.
-func (mr *MockStorageMockRecorder) GetMovieFile(ctx, id any) *gomock.Call {
+// GetMovieByMovieFileID indicates an expected call of GetMovieByMovieFileID.
+func (mr *MockStorageMockRecorder) GetMovieByMovieFileID(ctx, fileID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMovieFile", reflect.TypeOf((*MockStorage)(nil).GetMovieFile), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMovieByMovieFileID", reflect.TypeOf((*MockStorage)(nil).GetMovieByMovieFileID), ctx, fileID)
+}
+
+// GetMovieFiles mocks base method.
+func (m *MockStorage) GetMovieFiles(ctx context.Context, id int64) ([]*model.MovieFile, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMovieFiles", ctx, id)
+	ret0, _ := ret[0].([]*model.MovieFile)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMovieFiles indicates an expected call of GetMovieFiles.
+func (mr *MockStorageMockRecorder) GetMovieFiles(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMovieFiles", reflect.TypeOf((*MockStorage)(nil).GetMovieFiles), ctx, id)
 }
 
 // GetMovieMetadata mocks base method.
@@ -546,6 +561,20 @@ func (m *MockStorage) ListQualityProfiles(ctx context.Context) ([]*storage.Quali
 func (mr *MockStorageMockRecorder) ListQualityProfiles(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListQualityProfiles", reflect.TypeOf((*MockStorage)(nil).ListQualityProfiles), ctx)
+}
+
+// UpdateMovieMovieFileID mocks base method.
+func (m *MockStorage) UpdateMovieMovieFileID(ctx context.Context, id, fileID int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMovieMovieFileID", ctx, id, fileID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateMovieMovieFileID indicates an expected call of UpdateMovieMovieFileID.
+func (mr *MockStorageMockRecorder) UpdateMovieMovieFileID(ctx, id, fileID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMovieMovieFileID", reflect.TypeOf((*MockStorage)(nil).UpdateMovieMovieFileID), ctx, id, fileID)
 }
 
 // UpdateMovieState mocks base method.
@@ -940,19 +969,34 @@ func (mr *MockMovieStorageMockRecorder) GetMovieByMetadataID(ctx, metadataID any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMovieByMetadataID", reflect.TypeOf((*MockMovieStorage)(nil).GetMovieByMetadataID), ctx, metadataID)
 }
 
-// GetMovieFile mocks base method.
-func (m *MockMovieStorage) GetMovieFile(ctx context.Context, id int64) (model.MovieFile, error) {
+// GetMovieByMovieFileID mocks base method.
+func (m *MockMovieStorage) GetMovieByMovieFileID(ctx context.Context, fileID int64) (*storage.Movie, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMovieFile", ctx, id)
-	ret0, _ := ret[0].(model.MovieFile)
+	ret := m.ctrl.Call(m, "GetMovieByMovieFileID", ctx, fileID)
+	ret0, _ := ret[0].(*storage.Movie)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetMovieFile indicates an expected call of GetMovieFile.
-func (mr *MockMovieStorageMockRecorder) GetMovieFile(ctx, id any) *gomock.Call {
+// GetMovieByMovieFileID indicates an expected call of GetMovieByMovieFileID.
+func (mr *MockMovieStorageMockRecorder) GetMovieByMovieFileID(ctx, fileID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMovieFile", reflect.TypeOf((*MockMovieStorage)(nil).GetMovieFile), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMovieByMovieFileID", reflect.TypeOf((*MockMovieStorage)(nil).GetMovieByMovieFileID), ctx, fileID)
+}
+
+// GetMovieFiles mocks base method.
+func (m *MockMovieStorage) GetMovieFiles(ctx context.Context, id int64) ([]*model.MovieFile, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMovieFiles", ctx, id)
+	ret0, _ := ret[0].([]*model.MovieFile)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMovieFiles indicates an expected call of GetMovieFiles.
+func (mr *MockMovieStorageMockRecorder) GetMovieFiles(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMovieFiles", reflect.TypeOf((*MockMovieStorage)(nil).GetMovieFiles), ctx, id)
 }
 
 // ListMovieFiles mocks base method.
@@ -998,6 +1042,20 @@ func (m *MockMovieStorage) ListMoviesByState(ctx context.Context, state storage.
 func (mr *MockMovieStorageMockRecorder) ListMoviesByState(ctx, state any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMoviesByState", reflect.TypeOf((*MockMovieStorage)(nil).ListMoviesByState), ctx, state)
+}
+
+// UpdateMovieMovieFileID mocks base method.
+func (m *MockMovieStorage) UpdateMovieMovieFileID(ctx context.Context, id, fileID int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMovieMovieFileID", ctx, id, fileID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateMovieMovieFileID indicates an expected call of UpdateMovieMovieFileID.
+func (mr *MockMovieStorageMockRecorder) UpdateMovieMovieFileID(ctx, id, fileID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMovieMovieFileID", reflect.TypeOf((*MockMovieStorage)(nil).UpdateMovieMovieFileID), ctx, id, fileID)
 }
 
 // UpdateMovieState mocks base method.

--- a/pkg/storage/sqlite/schema/gen/model/movie_file.go
+++ b/pkg/storage/sqlite/schema/gen/model/movie_file.go
@@ -13,7 +13,6 @@ import (
 
 type MovieFile struct {
 	ID               int32 `sql:"primary_key"`
-	MovieID          int32
 	Quality          string
 	Size             int64
 	DateAdded        time.Time

--- a/pkg/storage/sqlite/schema/gen/table/movie_file.go
+++ b/pkg/storage/sqlite/schema/gen/table/movie_file.go
@@ -18,7 +18,6 @@ type movieFileTable struct {
 
 	// Columns
 	ID               sqlite.ColumnInteger
-	MovieID          sqlite.ColumnInteger
 	Quality          sqlite.ColumnString
 	Size             sqlite.ColumnInteger
 	DateAdded        sqlite.ColumnTimestamp
@@ -71,7 +70,6 @@ func newMovieFileTable(schemaName, tableName, alias string) *MovieFileTable {
 func newMovieFileTableImpl(schemaName, tableName, alias string) movieFileTable {
 	var (
 		IDColumn               = sqlite.IntegerColumn("id")
-		MovieIDColumn          = sqlite.IntegerColumn("movie_id")
 		QualityColumn          = sqlite.StringColumn("quality")
 		SizeColumn             = sqlite.IntegerColumn("size")
 		DateAddedColumn        = sqlite.TimestampColumn("date_added")
@@ -83,8 +81,8 @@ func newMovieFileTableImpl(schemaName, tableName, alias string) movieFileTable {
 		LanguagesColumn        = sqlite.StringColumn("languages")
 		IndexerFlagsColumn     = sqlite.IntegerColumn("indexer_flags")
 		OriginalFilePathColumn = sqlite.StringColumn("original_file_path")
-		allColumns             = sqlite.ColumnList{IDColumn, MovieIDColumn, QualityColumn, SizeColumn, DateAddedColumn, SceneNameColumn, MediaInfoColumn, ReleaseGroupColumn, RelativePathColumn, EditionColumn, LanguagesColumn, IndexerFlagsColumn, OriginalFilePathColumn}
-		mutableColumns         = sqlite.ColumnList{MovieIDColumn, QualityColumn, SizeColumn, DateAddedColumn, SceneNameColumn, MediaInfoColumn, ReleaseGroupColumn, RelativePathColumn, EditionColumn, LanguagesColumn, IndexerFlagsColumn, OriginalFilePathColumn}
+		allColumns             = sqlite.ColumnList{IDColumn, QualityColumn, SizeColumn, DateAddedColumn, SceneNameColumn, MediaInfoColumn, ReleaseGroupColumn, RelativePathColumn, EditionColumn, LanguagesColumn, IndexerFlagsColumn, OriginalFilePathColumn}
+		mutableColumns         = sqlite.ColumnList{QualityColumn, SizeColumn, DateAddedColumn, SceneNameColumn, MediaInfoColumn, ReleaseGroupColumn, RelativePathColumn, EditionColumn, LanguagesColumn, IndexerFlagsColumn, OriginalFilePathColumn}
 	)
 
 	return movieFileTable{
@@ -92,7 +90,6 @@ func newMovieFileTableImpl(schemaName, tableName, alias string) movieFileTable {
 
 		//Columns
 		ID:               IDColumn,
-		MovieID:          MovieIDColumn,
 		Quality:          QualityColumn,
 		Size:             SizeColumn,
 		DateAdded:        DateAddedColumn,

--- a/pkg/storage/sqlite/schema/schema.sql
+++ b/pkg/storage/sqlite/schema/schema.sql
@@ -33,7 +33,6 @@ CREATE TABLE IF NOT EXISTS "quality_profile_item" (
 
 CREATE TABLE IF NOT EXISTS "movie_file" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    "movie_id" INTEGER UNIQUE NOT NULL,
     "quality" TEXT NOT NULL,
     "size" BIGINT NOT NULL,
     "date_added" DATETIME NOT NULL DEFAULT current_timestamp,

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -176,6 +176,25 @@ func (s SQLite) GetMovie(ctx context.Context, id int64) (*storage.Movie, error) 
 	return movie, err
 }
 
+func (s SQLite) GetMovieByMovieFileID(ctx context.Context, fileID int64) (*storage.Movie, error) {
+	stmt := sqlite.
+		SELECT(
+			table.Movie.AllColumns,
+			table.MovieTransition.AllColumns).
+		FROM(
+			table.Movie.INNER_JOIN(
+				table.MovieTransition,
+				table.Movie.ID.EQ(table.MovieTransition.MovieID))).
+		WHERE(
+			table.Movie.MovieFileID.EQ(sqlite.Int(fileID)).
+				AND(table.MovieTransition.MostRecent.EQ(sqlite.Bool(true))),
+		)
+
+	movie := new(storage.Movie)
+	err := stmt.QueryContext(ctx, s.db, movie)
+	return movie, err
+}
+
 // ListMovies lists the stored movies
 func (s SQLite) ListMovies(ctx context.Context) ([]*storage.Movie, error) {
 	movies := make([]*storage.Movie, 0)
@@ -332,7 +351,7 @@ func (s SQLite) GetMovieFiles(ctx context.Context, id int64) ([]*model.MovieFile
 	stmt := table.MovieFile.
 		SELECT(table.MovieFile.AllColumns).
 		FROM(table.MovieFile).
-		WHERE(table.MovieFile.MovieID.EQ(sqlite.Int64(id)))
+		WHERE(table.MovieFile.ID.EQ(sqlite.Int64(id)))
 
 	var result []*model.MovieFile
 	err := stmt.QueryContext(ctx, s.db, &result)

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -229,6 +229,14 @@ func (s SQLite) DeleteMovie(ctx context.Context, id int64) error {
 	return nil
 }
 
+// UpdateMovieMovieFileID updates the movie file id for a movie
+func (s SQLite) UpdateMovieMovieFileID(ctx context.Context, id int64, fileID int64) error {
+	stmt := table.Movie.UPDATE().
+		SET(table.Movie.MovieFileID.SET(sqlite.Int64(fileID))).WHERE(table.Movie.ID.EQ(sqlite.Int64(id)))
+	_, err := s.handleStatement(ctx, stmt)
+	return err
+}
+
 // UpdateMovieState updates the transition state of a movie. Metadata is optional and can be nil
 func (s SQLite) UpdateMovieState(ctx context.Context, id int64, state storage.MovieState, metadata *storage.MovieStateMetadata) error {
 	movie, err := s.GetMovie(ctx, id)

--- a/pkg/storage/sqlite/sqlite_test.go
+++ b/pkg/storage/sqlite/sqlite_test.go
@@ -149,7 +149,6 @@ func TestMovieStorage(t *testing.T) {
 		ID:      1,
 		Quality: "HDTV-720p",
 		Size:    1_000_000_000,
-		MovieID: 1,
 	}
 	res, err = store.CreateMovieFile(ctx, file)
 	assert.Nil(t, err)
@@ -489,5 +488,41 @@ func TestSQLite_UpdateMovieMovieFileID(t *testing.T) {
 
 		assert.Equal(t, int32(1), movie.ID)
 		assert.Equal(t, int32(2), *movie.MovieFileID)
+	})
+}
+
+func TestSQLite_GetMovieByMovieFileID(t *testing.T) {
+	t.Run("get movie by movie file id", func(t *testing.T) {
+		ctx := context.Background()
+		store := initSqlite(t, ctx)
+		require.NotNil(t, store)
+
+		path := "Title/Title.mkv"
+		movie1 := storage.Movie{
+			Movie: model.Movie{
+				Monitored:   1,
+				Path:        &path,
+				MovieFileID: ptr(int32(1)),
+			},
+		}
+
+		_, err := store.CreateMovie(ctx, movie1, storage.MovieStateDiscovered)
+		require.NoError(t, err)
+
+		movie2 := storage.Movie{
+			Movie: model.Movie{
+				Monitored:   1,
+				Path:        &path,
+				MovieFileID: ptr(int32(2)),
+			},
+		}
+		_, err = store.CreateMovie(ctx, movie2, storage.MovieStateDiscovered)
+		require.NoError(t, err)
+
+		movie, err := store.GetMovieByMovieFileID(ctx, 1)
+		require.NoError(t, err)
+
+		assert.Equal(t, int32(1), movie.ID)
+		assert.Equal(t, int32(1), int32(*movie.MovieFileID))
 	})
 }

--- a/pkg/storage/sqlite/sqlite_test.go
+++ b/pkg/storage/sqlite/sqlite_test.go
@@ -19,6 +19,10 @@ func TestInit(t *testing.T) {
 	assert.NotNil(t, store)
 }
 
+func ptr[A any](thing A) *A {
+	return &thing
+}
+
 func initSqlite(t *testing.T, ctx context.Context) storage.Storage {
 	store, err := New(":memory:")
 	assert.Nil(t, err)
@@ -77,8 +81,8 @@ func TestMovieStorage(t *testing.T) {
 			ID:              1,
 			Path:            &path,
 			Monitored:       1,
-			MovieFileID:     intPtr(1),
-			MovieMetadataID: intPtr(1),
+			MovieFileID:     ptr(int32(1)),
+			MovieMetadataID: ptr(int32(1)),
 		},
 	}
 
@@ -87,8 +91,8 @@ func TestMovieStorage(t *testing.T) {
 			ID:              1,
 			Path:            &path,
 			Monitored:       1,
-			MovieFileID:     intPtr(1),
-			MovieMetadataID: intPtr(1),
+			MovieFileID:     ptr(int32(1)),
+			MovieMetadataID: ptr(int32(1)),
 		},
 		State: storage.MovieStateMissing,
 	}
@@ -111,8 +115,8 @@ func TestMovieStorage(t *testing.T) {
 	assert.Equal(t, &wantMovie, actual)
 
 	err = store.UpdateMovieState(ctx, int64(movies[0].ID), storage.MovieStateDownloading, &storage.MovieStateMetadata{
-		DownloadID:       strPtr("123"),
-		DownloadClientID: intPtr(1),
+		DownloadID:       ptr("123"),
+		DownloadClientID: ptr(int32(1)),
 	})
 	assert.Nil(t, err)
 
@@ -457,11 +461,33 @@ func TestDownloadClientStorage(t *testing.T) {
 	err = store.DeleteDownloadClient(ctx, 2)
 	assert.Nil(t, err)
 }
+func TestSQLite_UpdateMovieMovieFileID(t *testing.T) {
+	t.Run("update movie file id", func(t *testing.T) {
+		ctx := context.Background()
+		store := initSqlite(t, ctx)
+		require.NotNil(t, store)
 
-func intPtr(i int32) *int32 {
-	return &i
-}
+		path := "Title/Title.mkv"
+		newMovie := storage.Movie{
+			Movie: model.Movie{
+				ID:          1,
+				Monitored:   1,
+				Path:        &path,
+				MovieFileID: ptr(int32(1)),
+			},
+		}
 
-func strPtr(i string) *string {
-	return &i
+		movieID, err := store.CreateMovie(ctx, newMovie, storage.MovieStateDiscovered)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), movieID)
+
+		err = store.UpdateMovieMovieFileID(ctx, movieID, 2)
+		require.NoError(t, err)
+
+		movie, err := store.GetMovie(ctx, movieID)
+		require.NoError(t, err)
+
+		assert.Equal(t, int32(1), movie.ID)
+		assert.Equal(t, int32(2), *movie.MovieFileID)
+	})
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -86,6 +86,7 @@ type MovieStorage interface {
 	ListMoviesByState(ctx context.Context, state MovieState) ([]*Movie, error)
 	GetMovieByMetadataID(ctx context.Context, metadataID int) (*Movie, error)
 	UpdateMovieState(ctx context.Context, id int64, state MovieState, metadata *MovieStateMetadata) error
+	UpdateMovieMovieFileID(ctx context.Context, id int64, fileID int64) error
 
 	GetMovieFiles(ctx context.Context, id int64) ([]*model.MovieFile, error)
 	CreateMovieFile(ctx context.Context, movieFile model.MovieFile) (int64, error)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -80,11 +80,12 @@ func (m Movie) Machine() *machine.StateMachine[MovieState] {
 
 type MovieStorage interface {
 	GetMovie(ctx context.Context, id int64) (*Movie, error)
+	GetMovieByMovieFileID(ctx context.Context, fileID int64) (*Movie, error)
+	GetMovieByMetadataID(ctx context.Context, metadataID int) (*Movie, error)
 	CreateMovie(ctx context.Context, movie Movie, state MovieState) (int64, error)
 	DeleteMovie(ctx context.Context, id int64) error
 	ListMovies(ctx context.Context) ([]*Movie, error)
 	ListMoviesByState(ctx context.Context, state MovieState) ([]*Movie, error)
-	GetMovieByMetadataID(ctx context.Context, metadataID int) (*Movie, error)
 	UpdateMovieState(ctx context.Context, id int64, state MovieState, metadata *MovieStateMetadata) error
 	UpdateMovieMovieFileID(ctx context.Context, id int64, fileID int64) error
 


### PR DESCRIPTION
When running the indexer loop, the media manager now...

1. Lists all movie files we currently have stored
2. For each each file we have discovered, if the file location for the relative or absolute path matches an existing movie file that is stored, we skip that file as its already been download or discovered.
3. For each new file, we store a new movie, store a new movie file that is the newly discovered movie, and then update the movie with the movie file ID.

I just made assumptions on the video file formats, not sure if I missed any there that we may want to add.

I tested this by creating a movie directory, adding a fake movie.mp4 and subtitles.stl, and once movie.mp4 was added initially it was skipped in each following loop.

Also removed some dead code.