### PR TITLE
28 improve reconcile loops

### DIFF
--- a/cmd/indexer.go
+++ b/cmd/indexer.go
@@ -143,7 +143,7 @@ var searchIndexerCmd = &cobra.Command{
 			log.Fatal("failed to init database", zap.Error(err))
 		}
 
-		m := manager.New(tmdbClient, prowlarrClient, library, store, nil)
+		m := manager.New(tmdbClient, prowlarrClient, library, store, nil, cfg.Manager)
 
 		ctx := logger.WithCtx(context.Background(), log)
 		idx, err := m.ListIndexers(ctx)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -58,4 +59,7 @@ func initConfig() {
 	viper.SetDefault("storage.filePath", "mediaz.sqlite")
 	viper.SetDefault("storage.schemas", []string{"./pkg/storage/sqlite/schema/schema.sql"})
 	viper.SetDefault("storage.tableValueSchemas", []string{"./pkg/storage/sqlite/schema/defaults.sql"})
+
+	viper.SetDefault("manager.reconciler.movie", time.Minute*10)
+	viper.SetDefault("manager.reconciler.movieLibraryIndex", time.Minute*10)
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -95,7 +95,7 @@ var serveCmd = &cobra.Command{
 		)
 
 		factory := download.NewDownloadClientFactory(cfg.Library.DownloadMountDir)
-		manager := manager.New(tmdbClient, prowlarrClient, library, store, factory)
+		manager := manager.New(tmdbClient, prowlarrClient, library, store, factory, cfg.Manager)
 
 		go func() {
 			log.Fatal(manager.Run(context.Background()))

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/spf13/viper"
 )
 
@@ -10,6 +12,7 @@ type Config struct {
 	Library  Library  `json:"library" yaml:"library" mapstructure:"library"`
 	Storage  Storage  `json:"storage" yaml:"storage" mapstructure:"storage"`
 	Server   Server   `json:"server" yaml:"server" mapstructure:"server"`
+	Manager  Manager  `json:"manager" yaml:"manager" mapstructure:"manager"`
 }
 
 type TMDB struct {
@@ -39,6 +42,16 @@ type Storage struct {
 	FilePath          string   `json:"filePath" yaml:"filePath" mapstructure:"filePath"`
 	Schemas           []string `json:"schemas"  yaml:"schemas" mapstructure:"schemas"`
 	TableValueSchemas []string `json:"tableValueSchemas" yaml:"tableValueSchemas" mapstructure:"tableValueSchemas"`
+}
+
+// Manager houses configuration related to the manager and reconcillation
+type Manager struct {
+	Jobs Jobs `json:"jobs" yaml:"jobs" mapstructure:"jobs"`
+}
+
+type Jobs struct {
+	MovieReconcile time.Duration `json:"movieReconcile" yaml:"movieReconcile" mapstructure:"movieReconcile"`
+	MovieIndex     time.Duration `json:"movieIndex" yaml:"movieIndex" mapstructure:"movieIndex"`
 }
 
 type ConfigUnmarshaler interface {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/kasuboski/mediaz/config/mocks"
 	"github.com/spf13/viper"
@@ -48,6 +49,12 @@ func TestNew(t *testing.T) {
 				Host:   "my-prowlarr-host",
 				APIKey: "my-prowlarr-api-key",
 			},
+			Manager: Manager{
+				Jobs: Jobs{
+					MovieIndex:     time.Minute * 15,
+					MovieReconcile: time.Minute * 10,
+				},
+			},
 		}
 
 		if !reflect.DeepEqual(c, wantConfig) {
@@ -61,6 +68,8 @@ func TestNew(t *testing.T) {
 		cu.SetDefault("tmdb.scheme", "https")
 		cu.SetDefault("tmdb.apiKey", "fake-key")
 		cu.SetDefault("prowlarr.scheme", "http")
+		cu.SetDefault("manager.jobs.movieIndex", time.Minute*15)
+		cu.SetDefault("manager.jobs.movieReconcile", time.Minute*10)
 		c, err := New(cu)
 		if err != nil {
 			t.Errorf("TestNew() err = %v, want %v", err, nil)
@@ -73,6 +82,12 @@ func TestNew(t *testing.T) {
 			},
 			Prowlarr: Prowlarr{
 				Scheme: "http",
+			},
+			Manager: Manager{
+				Jobs: Jobs{
+					MovieIndex:     time.Minute * 15,
+					MovieReconcile: time.Minute * 10,
+				},
 			},
 		}
 

--- a/config/testing/config.yaml
+++ b/config/testing/config.yaml
@@ -6,3 +6,7 @@ prowlarr:
   host: my-prowlarr-host
   scheme: https
   apiKey: my-prowlarr-api-key
+manager:
+  jobs:
+    movieIndex: 15m
+    movieReconcile: 10m

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -188,6 +188,7 @@ func (m MediaManager) Run(ctx context.Context) error {
 			return ctx.Err()
 		case <-movieIndexTicker.C:
 			if !movieIndexerLock.TryLock() {
+				log.Debug("movie indexer lock is locked")
 				continue
 			}
 			movieIndexerLock.Lock()
@@ -200,6 +201,7 @@ func (m MediaManager) Run(ctx context.Context) error {
 			}
 		case <-movieReconcileTicker.C:
 			if !movieReconcileLock.TryLock() {
+				log.Debug("movie reconcile lock is locked")
 				continue
 			}
 			movieReconcileLock.Lock()


### PR DESCRIPTION
Adding config driven time.Durations for the job tickers, default is 10m for each set with viper

Also added locks so the jobs dont immediate fire again if the previous loop has not finished yet