### PR TITLE
Feature/add new series

### DIFF
--- a/config/mocks/mock_config_unmarshaler.go
+++ b/config/mocks/mock_config_unmarshaler.go
@@ -20,6 +20,7 @@ import (
 type MockConfigUnmarshaler struct {
 	ctrl     *gomock.Controller
 	recorder *MockConfigUnmarshalerMockRecorder
+	isgomock struct{}
 }
 
 // MockConfigUnmarshalerMockRecorder is the mock recorder for MockConfigUnmarshaler.

--- a/pkg/storage/mocks/mock_storage.go
+++ b/pkg/storage/mocks/mock_storage.go
@@ -493,18 +493,18 @@ func (mr *MockStorageMockRecorder) GetDownloadClient(ctx, id any) *gomock.Call {
 }
 
 // GetEpisode mocks base method.
-func (m *MockStorage) GetEpisode(ctx context.Context, id int64) (*storage.Episode, error) {
+func (m *MockStorage) GetEpisode(ctx context.Context, where sqlite.BoolExpression) (*storage.Episode, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEpisode", ctx, id)
+	ret := m.ctrl.Call(m, "GetEpisode", ctx, where)
 	ret0, _ := ret[0].(*storage.Episode)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetEpisode indicates an expected call of GetEpisode.
-func (mr *MockStorageMockRecorder) GetEpisode(ctx, id any) *gomock.Call {
+func (mr *MockStorageMockRecorder) GetEpisode(ctx, where any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpisode", reflect.TypeOf((*MockStorage)(nil).GetEpisode), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpisode", reflect.TypeOf((*MockStorage)(nil).GetEpisode), ctx, where)
 }
 
 // GetEpisodeByEpisodeFileID mocks base method.
@@ -688,18 +688,18 @@ func (mr *MockStorageMockRecorder) GetQualityProfileItem(ctx, id any) *gomock.Ca
 }
 
 // GetSeason mocks base method.
-func (m *MockStorage) GetSeason(ctx context.Context, id int64) (*storage.Season, error) {
+func (m *MockStorage) GetSeason(ctx context.Context, where sqlite.BoolExpression) (*storage.Season, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSeason", ctx, id)
+	ret := m.ctrl.Call(m, "GetSeason", ctx, where)
 	ret0, _ := ret[0].(*storage.Season)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSeason indicates an expected call of GetSeason.
-func (mr *MockStorageMockRecorder) GetSeason(ctx, id any) *gomock.Call {
+func (mr *MockStorageMockRecorder) GetSeason(ctx, where any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeason", reflect.TypeOf((*MockStorage)(nil).GetSeason), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeason", reflect.TypeOf((*MockStorage)(nil).GetSeason), ctx, where)
 }
 
 // GetSeasonMetadata mocks base method.
@@ -797,48 +797,43 @@ func (mr *MockStorageMockRecorder) ListEpisodeFiles(ctx any) *gomock.Call {
 }
 
 // ListEpisodeMetadata mocks base method.
-func (m *MockStorage) ListEpisodeMetadata(ctx context.Context) ([]*model.EpisodeMetadata, error) {
+func (m *MockStorage) ListEpisodeMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.EpisodeMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEpisodeMetadata", ctx)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListEpisodeMetadata", varargs...)
 	ret0, _ := ret[0].([]*model.EpisodeMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListEpisodeMetadata indicates an expected call of ListEpisodeMetadata.
-func (mr *MockStorageMockRecorder) ListEpisodeMetadata(ctx any) *gomock.Call {
+func (mr *MockStorageMockRecorder) ListEpisodeMetadata(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEpisodeMetadata", reflect.TypeOf((*MockStorage)(nil).ListEpisodeMetadata), ctx)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEpisodeMetadata", reflect.TypeOf((*MockStorage)(nil).ListEpisodeMetadata), varargs...)
 }
 
 // ListEpisodes mocks base method.
-func (m *MockStorage) ListEpisodes(ctx context.Context, seasonID int64) ([]*storage.Episode, error) {
+func (m *MockStorage) ListEpisodes(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.Episode, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEpisodes", ctx, seasonID)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListEpisodes", varargs...)
 	ret0, _ := ret[0].([]*storage.Episode)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListEpisodes indicates an expected call of ListEpisodes.
-func (mr *MockStorageMockRecorder) ListEpisodes(ctx, seasonID any) *gomock.Call {
+func (mr *MockStorageMockRecorder) ListEpisodes(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEpisodes", reflect.TypeOf((*MockStorage)(nil).ListEpisodes), ctx, seasonID)
-}
-
-// ListEpisodesByState mocks base method.
-func (m *MockStorage) ListEpisodesByState(ctx context.Context, state storage.EpisodeState) ([]*storage.Episode, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEpisodesByState", ctx, state)
-	ret0, _ := ret[0].([]*storage.Episode)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListEpisodesByState indicates an expected call of ListEpisodesByState.
-func (mr *MockStorageMockRecorder) ListEpisodesByState(ctx, state any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEpisodesByState", reflect.TypeOf((*MockStorage)(nil).ListEpisodesByState), ctx, state)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEpisodes", reflect.TypeOf((*MockStorage)(nil).ListEpisodes), varargs...)
 }
 
 // ListIndexers mocks base method.
@@ -962,63 +957,83 @@ func (mr *MockStorageMockRecorder) ListQualityProfiles(ctx any) *gomock.Call {
 }
 
 // ListSeasonMetadata mocks base method.
-func (m *MockStorage) ListSeasonMetadata(ctx context.Context) ([]*model.SeasonMetadata, error) {
+func (m *MockStorage) ListSeasonMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.SeasonMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSeasonMetadata", ctx)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSeasonMetadata", varargs...)
 	ret0, _ := ret[0].([]*model.SeasonMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSeasonMetadata indicates an expected call of ListSeasonMetadata.
-func (mr *MockStorageMockRecorder) ListSeasonMetadata(ctx any) *gomock.Call {
+func (mr *MockStorageMockRecorder) ListSeasonMetadata(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeasonMetadata", reflect.TypeOf((*MockStorage)(nil).ListSeasonMetadata), ctx)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeasonMetadata", reflect.TypeOf((*MockStorage)(nil).ListSeasonMetadata), varargs...)
 }
 
 // ListSeasons mocks base method.
-func (m *MockStorage) ListSeasons(ctx context.Context, SeriesID int64) ([]*storage.Season, error) {
+func (m *MockStorage) ListSeasons(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.Season, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSeasons", ctx, SeriesID)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSeasons", varargs...)
 	ret0, _ := ret[0].([]*storage.Season)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSeasons indicates an expected call of ListSeasons.
-func (mr *MockStorageMockRecorder) ListSeasons(ctx, SeriesID any) *gomock.Call {
+func (mr *MockStorageMockRecorder) ListSeasons(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeasons", reflect.TypeOf((*MockStorage)(nil).ListSeasons), ctx, SeriesID)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeasons", reflect.TypeOf((*MockStorage)(nil).ListSeasons), varargs...)
 }
 
 // ListSeries mocks base method.
-func (m *MockStorage) ListSeries(ctx context.Context) ([]*storage.Series, error) {
+func (m *MockStorage) ListSeries(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.Series, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSeries", ctx)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSeries", varargs...)
 	ret0, _ := ret[0].([]*storage.Series)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSeries indicates an expected call of ListSeries.
-func (mr *MockStorageMockRecorder) ListSeries(ctx any) *gomock.Call {
+func (mr *MockStorageMockRecorder) ListSeries(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeries", reflect.TypeOf((*MockStorage)(nil).ListSeries), ctx)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeries", reflect.TypeOf((*MockStorage)(nil).ListSeries), varargs...)
 }
 
 // ListSeriesMetadata mocks base method.
-func (m *MockStorage) ListSeriesMetadata(ctx context.Context) ([]*model.SeriesMetadata, error) {
+func (m *MockStorage) ListSeriesMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.SeriesMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSeriesMetadata", ctx)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSeriesMetadata", varargs...)
 	ret0, _ := ret[0].([]*model.SeriesMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSeriesMetadata indicates an expected call of ListSeriesMetadata.
-func (mr *MockStorageMockRecorder) ListSeriesMetadata(ctx any) *gomock.Call {
+func (mr *MockStorageMockRecorder) ListSeriesMetadata(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeriesMetadata", reflect.TypeOf((*MockStorage)(nil).ListSeriesMetadata), ctx)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeriesMetadata", reflect.TypeOf((*MockStorage)(nil).ListSeriesMetadata), varargs...)
 }
 
 // UpdateEpisodeEpisodeFileID mocks base method.
@@ -1863,18 +1878,18 @@ func (mr *MockSeriesStorageMockRecorder) DeleteSeries(ctx, id any) *gomock.Call 
 }
 
 // GetEpisode mocks base method.
-func (m *MockSeriesStorage) GetEpisode(ctx context.Context, id int64) (*storage.Episode, error) {
+func (m *MockSeriesStorage) GetEpisode(ctx context.Context, where sqlite.BoolExpression) (*storage.Episode, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEpisode", ctx, id)
+	ret := m.ctrl.Call(m, "GetEpisode", ctx, where)
 	ret0, _ := ret[0].(*storage.Episode)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetEpisode indicates an expected call of GetEpisode.
-func (mr *MockSeriesStorageMockRecorder) GetEpisode(ctx, id any) *gomock.Call {
+func (mr *MockSeriesStorageMockRecorder) GetEpisode(ctx, where any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpisode", reflect.TypeOf((*MockSeriesStorage)(nil).GetEpisode), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpisode", reflect.TypeOf((*MockSeriesStorage)(nil).GetEpisode), ctx, where)
 }
 
 // GetEpisodeByEpisodeFileID mocks base method.
@@ -1908,18 +1923,18 @@ func (mr *MockSeriesStorageMockRecorder) GetEpisodeFiles(ctx, id any) *gomock.Ca
 }
 
 // GetSeason mocks base method.
-func (m *MockSeriesStorage) GetSeason(ctx context.Context, id int64) (*storage.Season, error) {
+func (m *MockSeriesStorage) GetSeason(ctx context.Context, where sqlite.BoolExpression) (*storage.Season, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSeason", ctx, id)
+	ret := m.ctrl.Call(m, "GetSeason", ctx, where)
 	ret0, _ := ret[0].(*storage.Season)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSeason indicates an expected call of GetSeason.
-func (mr *MockSeriesStorageMockRecorder) GetSeason(ctx, id any) *gomock.Call {
+func (mr *MockSeriesStorageMockRecorder) GetSeason(ctx, where any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeason", reflect.TypeOf((*MockSeriesStorage)(nil).GetSeason), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeason", reflect.TypeOf((*MockSeriesStorage)(nil).GetSeason), ctx, where)
 }
 
 // GetSeries mocks base method.
@@ -1953,63 +1968,63 @@ func (mr *MockSeriesStorageMockRecorder) ListEpisodeFiles(ctx any) *gomock.Call 
 }
 
 // ListEpisodes mocks base method.
-func (m *MockSeriesStorage) ListEpisodes(ctx context.Context, seasonID int64) ([]*storage.Episode, error) {
+func (m *MockSeriesStorage) ListEpisodes(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.Episode, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEpisodes", ctx, seasonID)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListEpisodes", varargs...)
 	ret0, _ := ret[0].([]*storage.Episode)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListEpisodes indicates an expected call of ListEpisodes.
-func (mr *MockSeriesStorageMockRecorder) ListEpisodes(ctx, seasonID any) *gomock.Call {
+func (mr *MockSeriesStorageMockRecorder) ListEpisodes(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEpisodes", reflect.TypeOf((*MockSeriesStorage)(nil).ListEpisodes), ctx, seasonID)
-}
-
-// ListEpisodesByState mocks base method.
-func (m *MockSeriesStorage) ListEpisodesByState(ctx context.Context, state storage.EpisodeState) ([]*storage.Episode, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEpisodesByState", ctx, state)
-	ret0, _ := ret[0].([]*storage.Episode)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListEpisodesByState indicates an expected call of ListEpisodesByState.
-func (mr *MockSeriesStorageMockRecorder) ListEpisodesByState(ctx, state any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEpisodesByState", reflect.TypeOf((*MockSeriesStorage)(nil).ListEpisodesByState), ctx, state)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEpisodes", reflect.TypeOf((*MockSeriesStorage)(nil).ListEpisodes), varargs...)
 }
 
 // ListSeasons mocks base method.
-func (m *MockSeriesStorage) ListSeasons(ctx context.Context, SeriesID int64) ([]*storage.Season, error) {
+func (m *MockSeriesStorage) ListSeasons(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.Season, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSeasons", ctx, SeriesID)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSeasons", varargs...)
 	ret0, _ := ret[0].([]*storage.Season)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSeasons indicates an expected call of ListSeasons.
-func (mr *MockSeriesStorageMockRecorder) ListSeasons(ctx, SeriesID any) *gomock.Call {
+func (mr *MockSeriesStorageMockRecorder) ListSeasons(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeasons", reflect.TypeOf((*MockSeriesStorage)(nil).ListSeasons), ctx, SeriesID)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeasons", reflect.TypeOf((*MockSeriesStorage)(nil).ListSeasons), varargs...)
 }
 
 // ListSeries mocks base method.
-func (m *MockSeriesStorage) ListSeries(ctx context.Context) ([]*storage.Series, error) {
+func (m *MockSeriesStorage) ListSeries(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.Series, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSeries", ctx)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSeries", varargs...)
 	ret0, _ := ret[0].([]*storage.Series)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSeries indicates an expected call of ListSeries.
-func (mr *MockSeriesStorageMockRecorder) ListSeries(ctx any) *gomock.Call {
+func (mr *MockSeriesStorageMockRecorder) ListSeries(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeries", reflect.TypeOf((*MockSeriesStorage)(nil).ListSeries), ctx)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeries", reflect.TypeOf((*MockSeriesStorage)(nil).ListSeries), varargs...)
 }
 
 // UpdateEpisodeEpisodeFileID mocks base method.
@@ -2182,46 +2197,61 @@ func (mr *MockSeriesMetadataStorageMockRecorder) GetSeriesMetadata(ctx, where an
 }
 
 // ListEpisodeMetadata mocks base method.
-func (m *MockSeriesMetadataStorage) ListEpisodeMetadata(ctx context.Context) ([]*model.EpisodeMetadata, error) {
+func (m *MockSeriesMetadataStorage) ListEpisodeMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.EpisodeMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEpisodeMetadata", ctx)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListEpisodeMetadata", varargs...)
 	ret0, _ := ret[0].([]*model.EpisodeMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListEpisodeMetadata indicates an expected call of ListEpisodeMetadata.
-func (mr *MockSeriesMetadataStorageMockRecorder) ListEpisodeMetadata(ctx any) *gomock.Call {
+func (mr *MockSeriesMetadataStorageMockRecorder) ListEpisodeMetadata(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEpisodeMetadata", reflect.TypeOf((*MockSeriesMetadataStorage)(nil).ListEpisodeMetadata), ctx)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEpisodeMetadata", reflect.TypeOf((*MockSeriesMetadataStorage)(nil).ListEpisodeMetadata), varargs...)
 }
 
 // ListSeasonMetadata mocks base method.
-func (m *MockSeriesMetadataStorage) ListSeasonMetadata(ctx context.Context) ([]*model.SeasonMetadata, error) {
+func (m *MockSeriesMetadataStorage) ListSeasonMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.SeasonMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSeasonMetadata", ctx)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSeasonMetadata", varargs...)
 	ret0, _ := ret[0].([]*model.SeasonMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSeasonMetadata indicates an expected call of ListSeasonMetadata.
-func (mr *MockSeriesMetadataStorageMockRecorder) ListSeasonMetadata(ctx any) *gomock.Call {
+func (mr *MockSeriesMetadataStorageMockRecorder) ListSeasonMetadata(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeasonMetadata", reflect.TypeOf((*MockSeriesMetadataStorage)(nil).ListSeasonMetadata), ctx)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeasonMetadata", reflect.TypeOf((*MockSeriesMetadataStorage)(nil).ListSeasonMetadata), varargs...)
 }
 
 // ListSeriesMetadata mocks base method.
-func (m *MockSeriesMetadataStorage) ListSeriesMetadata(ctx context.Context) ([]*model.SeriesMetadata, error) {
+func (m *MockSeriesMetadataStorage) ListSeriesMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.SeriesMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSeriesMetadata", ctx)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSeriesMetadata", varargs...)
 	ret0, _ := ret[0].([]*model.SeriesMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListSeriesMetadata indicates an expected call of ListSeriesMetadata.
-func (mr *MockSeriesMetadataStorageMockRecorder) ListSeriesMetadata(ctx any) *gomock.Call {
+func (mr *MockSeriesMetadataStorageMockRecorder) ListSeriesMetadata(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeriesMetadata", reflect.TypeOf((*MockSeriesMetadataStorage)(nil).ListSeriesMetadata), ctx)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeriesMetadata", reflect.TypeOf((*MockSeriesMetadataStorage)(nil).ListSeriesMetadata), varargs...)
 }

--- a/pkg/storage/sqlite/schema/gen/model/season.go
+++ b/pkg/storage/sqlite/schema/gen/model/season.go
@@ -11,4 +11,5 @@ type Season struct {
 	ID               int32 `sql:"primary_key"`
 	SeriesID         int32
 	SeasonMetadataID *int32
+	Monitored        int32
 }

--- a/pkg/storage/sqlite/schema/gen/table/season.go
+++ b/pkg/storage/sqlite/schema/gen/table/season.go
@@ -20,6 +20,7 @@ type seasonTable struct {
 	ID               sqlite.ColumnInteger
 	SeriesID         sqlite.ColumnInteger
 	SeasonMetadataID sqlite.ColumnInteger
+	Monitored        sqlite.ColumnInteger
 
 	AllColumns     sqlite.ColumnList
 	MutableColumns sqlite.ColumnList
@@ -63,8 +64,9 @@ func newSeasonTableImpl(schemaName, tableName, alias string) seasonTable {
 		IDColumn               = sqlite.IntegerColumn("id")
 		SeriesIDColumn         = sqlite.IntegerColumn("series_id")
 		SeasonMetadataIDColumn = sqlite.IntegerColumn("season_metadata_id")
-		allColumns             = sqlite.ColumnList{IDColumn, SeriesIDColumn, SeasonMetadataIDColumn}
-		mutableColumns         = sqlite.ColumnList{SeriesIDColumn, SeasonMetadataIDColumn}
+		MonitoredColumn        = sqlite.IntegerColumn("monitored")
+		allColumns             = sqlite.ColumnList{IDColumn, SeriesIDColumn, SeasonMetadataIDColumn, MonitoredColumn}
+		mutableColumns         = sqlite.ColumnList{SeriesIDColumn, SeasonMetadataIDColumn, MonitoredColumn}
 	)
 
 	return seasonTable{
@@ -74,6 +76,7 @@ func newSeasonTableImpl(schemaName, tableName, alias string) seasonTable {
 		ID:               IDColumn,
 		SeriesID:         SeriesIDColumn,
 		SeasonMetadataID: SeasonMetadataIDColumn,
+		Monitored:        MonitoredColumn,
 
 		AllColumns:     allColumns,
 		MutableColumns: mutableColumns,

--- a/pkg/storage/sqlite/schema/schema.sql
+++ b/pkg/storage/sqlite/schema/schema.sql
@@ -119,6 +119,7 @@ CREATE TABLE IF NOT EXISTS "season" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     "series_id" INTEGER NOT NULL,
     "season_metadata_id" INTEGER UNIQUE,
+    "monitored" INTEGER NOT NULL,
     FOREIGN KEY ("series_id") REFERENCES "series" ("id")
 );
 

--- a/pkg/storage/sqlite/series.go
+++ b/pkg/storage/sqlite/series.go
@@ -159,34 +159,6 @@ func (s SQLite) ListSeries(ctx context.Context, where ...sqlite.BoolExpression) 
 	return Series, nil
 }
 
-// ListSeries lists all Series
-func (s SQLite) ListSeriesByState(ctx context.Context, state storage.SeriesState) ([]*storage.Series, error) {
-	stmt := table.Series.
-		SELECT(
-			table.Series.AllColumns,
-			table.SeriesTransition.AllColumns,
-		).
-		FROM(
-			table.Series.
-				INNER_JOIN(
-					table.SeriesTransition,
-					table.Series.ID.EQ(table.SeriesTransition.SeriesID).
-						AND(table.SeriesTransition.MostRecent.EQ(sqlite.Bool(true)))),
-		).
-		WHERE(
-			table.SeriesTransition.MostRecent.EQ(sqlite.Bool(true).AND(
-				table.SeriesTransition.ToState.EQ(sqlite.String(string(state))))),
-		)
-
-	var Series []*storage.Series
-	err := stmt.QueryContext(ctx, s.db, &Series)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list Series: %w", err)
-	}
-
-	return Series, nil
-}
-
 // CreateSeason stores a season in the database
 func (s SQLite) CreateSeason(ctx context.Context, season storage.Season, initialState storage.SeasonState) (int64, error) {
 	if season.State == "" {

--- a/pkg/storage/sqlite/series.go
+++ b/pkg/storage/sqlite/series.go
@@ -132,7 +132,7 @@ func (s SQLite) DeleteSeries(ctx context.Context, id int64) error {
 }
 
 // ListSeries lists all Series
-func (s SQLite) ListSeries(ctx context.Context) ([]*storage.Series, error) {
+func (s SQLite) ListSeries(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.Series, error) {
 	stmt := table.Series.
 		SELECT(
 			table.Series.AllColumns,
@@ -144,6 +144,38 @@ func (s SQLite) ListSeries(ctx context.Context) ([]*storage.Series, error) {
 					table.SeriesTransition,
 					table.Series.ID.EQ(table.SeriesTransition.SeriesID).
 						AND(table.SeriesTransition.MostRecent.EQ(sqlite.Bool(true)))),
+		)
+
+	for _, w := range where {
+		stmt = stmt.WHERE(w)
+	}
+
+	var Series []*storage.Series
+	err := stmt.QueryContext(ctx, s.db, &Series)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Series: %w", err)
+	}
+
+	return Series, nil
+}
+
+// ListSeries lists all Series
+func (s SQLite) ListSeriesByState(ctx context.Context, state storage.SeriesState) ([]*storage.Series, error) {
+	stmt := table.Series.
+		SELECT(
+			table.Series.AllColumns,
+			table.SeriesTransition.AllColumns,
+		).
+		FROM(
+			table.Series.
+				INNER_JOIN(
+					table.SeriesTransition,
+					table.Series.ID.EQ(table.SeriesTransition.SeriesID).
+						AND(table.SeriesTransition.MostRecent.EQ(sqlite.Bool(true)))),
+		).
+		WHERE(
+			table.SeriesTransition.MostRecent.EQ(sqlite.Bool(true).AND(
+				table.SeriesTransition.ToState.EQ(sqlite.String(string(state))))),
 		)
 
 	var Series []*storage.Series
@@ -227,17 +259,18 @@ func (s SQLite) CreateSeason(ctx context.Context, season storage.Season, initial
 }
 
 // GetSeason gets a season by id
-func (s SQLite) GetSeason(ctx context.Context, id int64) (*storage.Season, error) {
-	stmt := sqlite.SELECT(
-		table.Season.AllColumns,
-		table.SeasonTransition.AllColumns,
-	).
+func (s SQLite) GetSeason(ctx context.Context, where sqlite.BoolExpression) (*storage.Season, error) {
+	stmt := sqlite.
+		SELECT(
+			table.Season.AllColumns,
+			table.SeasonTransition.AllColumns,
+		).
 		FROM(table.Season.
 			LEFT_JOIN(table.SeasonTransition,
 				table.Season.ID.EQ(table.SeasonTransition.SeasonID).
 					AND(table.SeasonTransition.MostRecent.IS_TRUE()),
 			)).
-		WHERE(table.Season.ID.EQ(sqlite.Int64(id)))
+		WHERE(where)
 
 	var season storage.Season
 	err := stmt.QueryContext(ctx, s.db, &season)
@@ -266,10 +299,23 @@ func (s SQLite) DeleteSeason(ctx context.Context, id int64) error {
 }
 
 // ListSeasons lists all seasons for a Series
-func (s SQLite) ListSeasons(ctx context.Context, SeriesID int64) ([]*storage.Season, error) {
-	stmt := table.Season.
-		SELECT(table.Season.AllColumns).
-		WHERE(table.Season.SeriesID.EQ(sqlite.Int64(SeriesID)))
+func (s SQLite) ListSeasons(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.Season, error) {
+
+	stmt := sqlite.
+		SELECT(
+			table.Season.AllColumns,
+			table.SeasonTransition.ToState,
+		).
+		FROM(table.Season.
+			LEFT_JOIN(table.SeasonTransition,
+				table.Season.ID.EQ(table.SeasonTransition.SeasonID).
+					AND(table.SeasonTransition.MostRecent.IS_TRUE()),
+			),
+		)
+
+	for _, w := range where {
+		stmt = stmt.WHERE(w)
+	}
 
 	var seasons []*storage.Season
 	err := stmt.QueryContext(ctx, s.db, &seasons)
@@ -352,17 +398,18 @@ func (s SQLite) CreateEpisode(ctx context.Context, episode storage.Episode, init
 }
 
 // GetEpisode gets an episode by id
-func (s SQLite) GetEpisode(ctx context.Context, id int64) (*storage.Episode, error) {
-	stmt := sqlite.SELECT(
-		table.Episode.AllColumns,
-		table.EpisodeTransition.AllColumns,
-	).
+func (s SQLite) GetEpisode(ctx context.Context, where sqlite.BoolExpression) (*storage.Episode, error) {
+	stmt := sqlite.
+		SELECT(
+			table.Episode.AllColumns,
+			table.EpisodeTransition.AllColumns,
+		).
 		FROM(table.Episode.
 			LEFT_JOIN(table.EpisodeTransition,
 				table.Episode.ID.EQ(table.EpisodeTransition.EpisodeID).
 					AND(table.EpisodeTransition.MostRecent.IS_TRUE()),
 			)).
-		WHERE(table.Episode.ID.EQ(sqlite.Int64(id)))
+		WHERE(where)
 
 	var episode storage.Episode
 	err := stmt.QueryContext(ctx, s.db, &episode)
@@ -391,48 +438,29 @@ func (s SQLite) DeleteEpisode(ctx context.Context, id int64) error {
 }
 
 // ListEpisodes lists all episodes for a season
-func (s SQLite) ListEpisodes(ctx context.Context, seasonID int64) ([]*storage.Episode, error) {
-	stmt := sqlite.SELECT(
-		table.Episode.AllColumns,
-		table.EpisodeTransition.ToState,
-		table.EpisodeTransition.DownloadID,
-		table.EpisodeTransition.DownloadClientID,
-	).
+func (s SQLite) ListEpisodes(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.Episode, error) {
+	stmt := sqlite.
+		SELECT(
+			table.Episode.AllColumns,
+			table.EpisodeTransition.ToState,
+			table.EpisodeTransition.DownloadID,
+			table.EpisodeTransition.DownloadClientID,
+		).
 		FROM(table.Episode.
 			LEFT_JOIN(table.EpisodeTransition,
 				table.Episode.ID.EQ(table.EpisodeTransition.EpisodeID).
 					AND(table.EpisodeTransition.MostRecent.IS_TRUE()),
-			)).
-		WHERE(table.Episode.SeasonID.EQ(sqlite.Int64(seasonID)))
+			),
+		)
+
+	for _, w := range where {
+		stmt = stmt.WHERE(w)
+	}
 
 	var episodes []*storage.Episode
 	err := stmt.QueryContext(ctx, s.db, &episodes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list episodes: %w", err)
-	}
-
-	return episodes, nil
-}
-
-// ListEpisodesByState lists all episodes in a given state
-func (s SQLite) ListEpisodesByState(ctx context.Context, state storage.EpisodeState) ([]*storage.Episode, error) {
-	stmt := sqlite.SELECT(
-		table.Episode.AllColumns,
-		table.EpisodeTransition.ToState,
-		table.EpisodeTransition.DownloadID,
-		table.EpisodeTransition.DownloadClientID,
-	).
-		FROM(table.Episode.
-			INNER_JOIN(table.EpisodeTransition,
-				table.Episode.ID.EQ(table.EpisodeTransition.EpisodeID).
-					AND(table.EpisodeTransition.MostRecent.IS_TRUE()),
-			)).
-		WHERE(table.EpisodeTransition.ToState.EQ(sqlite.String(string(state))))
-
-	var episodes []*storage.Episode
-	err := stmt.QueryContext(ctx, s.db, &episodes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list episodes by state: %w", err)
 	}
 
 	return episodes, nil
@@ -563,20 +591,20 @@ func (s SQLite) ListEpisodeFiles(ctx context.Context) ([]*model.EpisodeFile, err
 }
 
 // CreateSeriesMetadata creates the given series metadata
-func (s SQLite) CreateSeriesMetadata(ctx context.Context, SeriesMeta model.SeriesMetadata) (int64, error) {
+func (s SQLite) CreateSeriesMetadata(ctx context.Context, seriesMeta model.SeriesMetadata) (int64, error) {
 	setColumns := make([]sqlite.Expression, len(table.SeriesMetadata.MutableColumns))
 	for i, c := range table.SeriesMetadata.MutableColumns {
 		setColumns[i] = c
 	}
 	// don't insert a zeroed ID
 	insertColumns := table.SeriesMetadata.MutableColumns
-	if SeriesMeta.ID != 0 {
+	if seriesMeta.ID != 0 {
 		insertColumns = table.SeriesMetadata.AllColumns
 	}
 
 	stmt := table.SeriesMetadata.
 		INSERT(insertColumns).
-		MODEL(SeriesMeta).
+		MODEL(seriesMeta).
 		RETURNING(table.SeriesMetadata.ID).
 		ON_CONFLICT(table.SeriesMetadata.ID).
 		DO_UPDATE(sqlite.SET(table.SeriesMetadata.MutableColumns.SET(sqlite.ROW(setColumns...))))
@@ -609,10 +637,14 @@ func (s SQLite) DeleteSeriesMetadata(ctx context.Context, id int64) error {
 }
 
 // ListSeriesMetadata lists all Series metadata
-func (s SQLite) ListSeriesMetadata(ctx context.Context) ([]*model.SeriesMetadata, error) {
+func (s SQLite) ListSeriesMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.SeriesMetadata, error) {
 	stmt := table.SeriesMetadata.
 		SELECT(table.SeriesMetadata.AllColumns).
 		FROM(table.SeriesMetadata)
+
+	for _, w := range where {
+		stmt = stmt.WHERE(w)
+	}
 
 	var SeriesMetadata []*model.SeriesMetadata
 	err := stmt.QueryContext(ctx, s.db, &SeriesMetadata)
@@ -689,10 +721,14 @@ func (s SQLite) DeleteSeasonMetadata(ctx context.Context, id int64) error {
 }
 
 // ListSeasonMetadata lists all season metadata
-func (s SQLite) ListSeasonMetadata(ctx context.Context) ([]*model.SeasonMetadata, error) {
+func (s SQLite) ListSeasonMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.SeasonMetadata, error) {
 	stmt := table.SeasonMetadata.
 		SELECT(table.SeasonMetadata.AllColumns).
 		FROM(table.SeasonMetadata)
+
+	for _, w := range where {
+		stmt = stmt.WHERE(w)
+	}
 
 	var seasonMetadata []*model.SeasonMetadata
 	err := stmt.QueryContext(ctx, s.db, &seasonMetadata)
@@ -769,10 +805,14 @@ func (s SQLite) DeleteEpisodeMetadata(ctx context.Context, id int64) error {
 }
 
 // ListEpisodeMetadata lists all episode metadata
-func (s SQLite) ListEpisodeMetadata(ctx context.Context) ([]*model.EpisodeMetadata, error) {
+func (s SQLite) ListEpisodeMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.EpisodeMetadata, error) {
 	stmt := table.EpisodeMetadata.
 		SELECT(table.EpisodeMetadata.AllColumns).
 		FROM(table.EpisodeMetadata)
+
+	for _, w := range where {
+		stmt = stmt.WHERE(w)
+	}
 
 	var episodeMetadata []*model.EpisodeMetadata
 	err := stmt.QueryContext(ctx, s.db, &episodeMetadata)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -181,8 +181,8 @@ func (s Series) Machine() *machine.StateMachine[SeriesState] {
 type Season struct {
 	model.Season
 	State            SeasonState `alias:"season_transition.to_state" json:"state"`
-	DownloadID       string      `alias:"season_transition.download_id" json:"-"`
-	DownloadClientID int32       `alias:"season_transition.download_client_id" json:"-"`
+	DownloadID       string      `json:"-"`
+	DownloadClientID int32       `json:"-"`
 }
 
 type SeasonTransition model.SeasonTransition
@@ -215,21 +215,20 @@ func (e Episode) Machine() *machine.StateMachine[EpisodeState] {
 
 type SeriesStorage interface {
 	GetSeries(ctx context.Context, where sqlite.BoolExpression) (*Series, error)
-	CreateSeries(ctx context.Context, Series Series, initialState SeriesState) (int64, error)
+	CreateSeries(ctx context.Context, series Series, initialState SeriesState) (int64, error)
 	DeleteSeries(ctx context.Context, id int64) error
-	ListSeries(ctx context.Context) ([]*Series, error)
+	ListSeries(ctx context.Context, where ...sqlite.BoolExpression) ([]*Series, error)
 
-	GetSeason(ctx context.Context, id int64) (*Season, error)
+	GetSeason(ctx context.Context, where sqlite.BoolExpression) (*Season, error)
 	CreateSeason(ctx context.Context, season Season, initialState SeasonState) (int64, error)
 	DeleteSeason(ctx context.Context, id int64) error
-	ListSeasons(ctx context.Context, SeriesID int64) ([]*Season, error)
+	ListSeasons(ctx context.Context, where ...sqlite.BoolExpression) ([]*Season, error)
 
-	GetEpisode(ctx context.Context, id int64) (*Episode, error)
+	GetEpisode(ctx context.Context, where sqlite.BoolExpression) (*Episode, error)
 	GetEpisodeByEpisodeFileID(ctx context.Context, fileID int64) (*Episode, error)
 	CreateEpisode(ctx context.Context, episode Episode, initialState EpisodeState) (int64, error)
 	DeleteEpisode(ctx context.Context, id int64) error
-	ListEpisodes(ctx context.Context, seasonID int64) ([]*Episode, error)
-	ListEpisodesByState(ctx context.Context, state EpisodeState) ([]*Episode, error)
+	ListEpisodes(ctx context.Context, where ...sqlite.BoolExpression) ([]*Episode, error)
 	UpdateEpisodeEpisodeFileID(ctx context.Context, id int64, fileID int64) error
 
 	GetEpisodeFiles(ctx context.Context, id int64) ([]*model.EpisodeFile, error)
@@ -241,17 +240,17 @@ type SeriesStorage interface {
 type SeriesMetadataStorage interface {
 	CreateSeriesMetadata(ctx context.Context, SeriesMeta model.SeriesMetadata) (int64, error)
 	DeleteSeriesMetadata(ctx context.Context, id int64) error
-	ListSeriesMetadata(ctx context.Context) ([]*model.SeriesMetadata, error)
+	ListSeriesMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.SeriesMetadata, error)
 	GetSeriesMetadata(ctx context.Context, where sqlite.BoolExpression) (*model.SeriesMetadata, error)
 
 	CreateSeasonMetadata(ctx context.Context, seasonMeta model.SeasonMetadata) (int64, error)
 	DeleteSeasonMetadata(ctx context.Context, id int64) error
-	ListSeasonMetadata(ctx context.Context) ([]*model.SeasonMetadata, error)
+	ListSeasonMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.SeasonMetadata, error)
 	GetSeasonMetadata(ctx context.Context, where sqlite.BoolExpression) (*model.SeasonMetadata, error)
 
 	CreateEpisodeMetadata(ctx context.Context, episodeMeta model.EpisodeMetadata) (int64, error)
 	DeleteEpisodeMetadata(ctx context.Context, id int64) error
-	ListEpisodeMetadata(ctx context.Context) ([]*model.EpisodeMetadata, error)
+	ListEpisodeMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.EpisodeMetadata, error)
 	GetEpisodeMetadata(ctx context.Context, where sqlite.BoolExpression) (*model.EpisodeMetadata, error)
 }
 


### PR DESCRIPTION
I wanted to create the seasons and episodes with an initial state of missing. My thoughts are that we will need to track each individually.

We might need a different status for seasons where they are partially completed.. there are probably 2 scenarios
* All episodes in a season are released and failed to discover or download all of the episodes (partially completed?)
* All released episodes are downloaded, but the season isn't finished -> continuing status

I also changed the db interfaces to use where statements so we didn't have to create a new helper func each time we needed a different lookup.

I am planning to add the reconcile loop next for missing.. the thought is:
1. pull all series that are in a missing or incomplete state
2. pull all seasons that are in a missing or incomplete state within that series
3. pull all episodes that are in a missing or incomplete state within each season

This might change depending on how the indexers pull back results for each series, but that is the current game plan

With the new changes.. after adding a new series


### Series
```sql
sqlite> select * from series;
id  path        monitored  added                tmdb_id  quality_profile_id  series_metadata_id  last_search_time
--  ----------  ---------  -------------------  -------  ------------------  ------------------  ----------------
1   INVINCIBLE  1          2025-04-29 23:16:53  95557    2                   1                                   
```

```sql
sqlite> select * from series_transition;
id  series_id  to_state  from_state  most_recent  sort_key  created_at           updated_at         
--  ---------  --------  ----------  -----------  --------  -------------------  -------------------
1   1          missing               1            1         2025-04-29 23:16:53  2025-04-29 23:16:53
```

### Season

```sql
sqlite> select * from season;
id  series_id  season_metadata_id  monitored
--  ---------  ------------------  ---------
1   1          1                   1        
2   1          2                   1        
3   1          3                   1        
4   1          4                   1 
```

```sql
sqlite> select * from season_transition;
id  season_id  to_state  from_state  most_recent  sort_key  created_at           updated_at         
--  ---------  --------  ----------  -----------  --------  -------------------  -------------------
1   1          missing               1            1         2025-04-29 23:16:53  2025-04-29 23:16:53
2   2          missing               1            1         2025-04-29 23:16:53  2025-04-29 23:16:53
3   3          missing               1            1         2025-04-29 23:16:53  2025-04-29 23:16:53
4   4          missing               1            1         2025-04-29 23:16:53  2025-04-29 23:16:53
```


### Episode
```sql
sqlite> select * from episode;
id  season_id  episode_number  monitored  episode_metadata_id  episode_file_id  runtime
--  ---------  --------------  ---------  -------------------  ---------------  -------
1   1          1               1          1                                     56     
2   2          1               1          2                                     51     
3   2          2               1          3                                     48     
4   2          3               1          4                                     45     
5   2          4               1          5                                     48     
6   2          5               1          6                                     50     
7   2          6               1          7                                     48     
8   2          7               1          8                                     52     
9   2          8               1          9                                     48     
10  3          1               1          10                                    49     
11  3          2               1          11                                    50     
12  3          3               1          12                                    50     
13  3          4               1          13                                    47     
14  3          5               1          14                                    52     
15  3          6               1          15                                    51     
16  3          7               1          16                                    52     
17  3          8               1          17                                    54     
18  4          1               1          18                                    49     
19  4          2               1          19                                    49     
20  4          3               1          20                                    51     
21  4          4               1          21                                    50     
22  4          5               1          22                                    49     
23  4          6               1          23                                    55     
24  4          7               1          24                                    52     
25  4          8               1          25                                    46  
```

```sql
sqlite> select * from episode_transition;
id  episode_id  to_state  from_state  most_recent  sort_key  download_client_id  download_id  created_at           updated_at         
--  ----------  --------  ----------  -----------  --------  ------------------  -----------  -------------------  -------------------
1   1           missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
2   2           missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
3   3           missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
4   4           missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
5   5           missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
6   6           missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
7   7           missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
8   8           missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
9   9           missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
10  10          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
11  11          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
12  12          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
13  13          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
14  14          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
15  15          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
16  16          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
17  17          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
18  18          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
19  19          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
20  20          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
21  21          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
22  22          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
23  23          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
24  24          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
25  25          missing               1            1                                          2025-04-29 23:16:53  2025-04-29 23:16:53
```
