### PR TITLE
add episode quality profiles

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -387,7 +387,7 @@ type AddSeriesRequest struct {
 func (m MediaManager) AddMovieToLibrary(ctx context.Context, request AddMovieRequest) (*storage.Movie, error) {
 	log := logger.FromCtx(ctx)
 
-	profile, err := m.storage.GetQualityProfile(ctx, int64(request.QualityProfileID))
+	profile, err := m.GetQualityProfile(ctx, int64(request.QualityProfileID))
 	if err != nil {
 		log.Debug("failed to get quality profile", zap.Int32("id", request.QualityProfileID), zap.Error(err))
 		return nil, err
@@ -446,7 +446,7 @@ func (m MediaManager) AddMovieToLibrary(ctx context.Context, request AddMovieReq
 func (m MediaManager) AddSeriesToLibrary(ctx context.Context, request AddSeriesRequest) (*storage.Series, error) {
 	log := logger.FromCtx(ctx)
 
-	qualityProfile, err := m.storage.GetQualityProfile(ctx, int64(request.QualityProfileID))
+	qualityProfile, err := m.GetQualityProfile(ctx, int64(request.QualityProfileID))
 	if err != nil {
 		log.Debug("failed to get quality profile", zap.Int32("id", request.QualityProfileID), zap.Error(err))
 		return nil, err

--- a/pkg/manager/quality.go
+++ b/pkg/manager/quality.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-jet/jet/v2/sqlite"
 	"github.com/kasuboski/mediaz/pkg/storage"
 	"github.com/kasuboski/mediaz/pkg/storage/sqlite/schema/gen/model"
+	"github.com/kasuboski/mediaz/pkg/storage/sqlite/schema/gen/table"
 )
 
 // MeetsQualitySize checks if the given fileSize (MB) and runtime (min) fall within the QualitySize
@@ -66,6 +68,16 @@ func (m MediaManager) GetQualityDefinition(ctx context.Context, id int64) (model
 
 func (m MediaManager) GetQualityProfile(ctx context.Context, id int64) (storage.QualityProfile, error) {
 	return m.storage.GetQualityProfile(ctx, id)
+}
+
+func (m MediaManager) ListEpisodeQualityProfiles(ctx context.Context, id int64) ([]*storage.QualityProfile, error) {
+	where := table.QualityDefinition.MediaType.EQ(sqlite.String("episode"))
+	return m.storage.ListQualityProfiles(ctx, where)
+}
+
+func (m MediaManager) ListMovieQualityProfiles(ctx context.Context, id int64) ([]*storage.QualityProfile, error) {
+	where := table.QualityDefinition.MediaType.EQ(sqlite.String("movie"))
+	return m.storage.ListQualityProfiles(ctx, where)
 }
 
 func (m MediaManager) ListQualityProfiles(ctx context.Context) ([]*storage.QualityProfile, error) {

--- a/pkg/manager/quality_test.go
+++ b/pkg/manager/quality_test.go
@@ -1,10 +1,14 @@
 package manager
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/kasuboski/mediaz/pkg/storage"
+	mediaSqlite "github.com/kasuboski/mediaz/pkg/storage/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestQualitySizeCutoff(t *testing.T) {
@@ -58,4 +62,132 @@ func TestQualitySizeCutoff(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMediaManager_GetQualityProfile(t *testing.T) {
+	t.Run("get movie quality profile", func(t *testing.T) {
+		ctx := context.Background()
+		store, err := mediaSqlite.New(":memory:")
+		require.NoError(t, err)
+
+		schemas, err := storage.ReadSchemaFiles("../storage/sqlite/schema/schema.sql", "../storage/sqlite/schema/defaults.sql")
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		err = store.Init(ctx, schemas...)
+		require.NoError(t, err)
+
+		manager := MediaManager{
+			storage: store,
+		}
+
+		profile, err := manager.GetQualityProfile(ctx, 1)
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), profile.ID)
+		assert.Equal(t, "Standard Definition", profile.Name)
+		assert.Equal(t, int32(2), profile.CutoffQualityID)
+		assert.Equal(t, true, profile.UpgradeAllowed)
+		assert.Equal(t, "HDTV-720p", profile.Qualities[0].Name)
+		assert.Equal(t, float64(1999), profile.Qualities[0].PreferredSize)
+		assert.Equal(t, float64(17.1), profile.Qualities[0].MinSize)
+		assert.Equal(t, float64(2000), profile.Qualities[0].MaxSize)
+		assert.Equal(t, "movie", profile.Qualities[0].MediaType)
+	})
+
+	t.Run("get episode quality profile", func(t *testing.T) {
+		ctx := context.Background()
+		store, err := mediaSqlite.New(":memory:")
+		require.NoError(t, err)
+
+		schemas, err := storage.ReadSchemaFiles("../storage/sqlite/schema/schema.sql", "../storage/sqlite/schema/defaults.sql")
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		err = store.Init(ctx, schemas...)
+		require.NoError(t, err)
+
+		manager := MediaManager{
+			storage: store,
+		}
+
+		profile, err := manager.GetQualityProfile(ctx, 5)
+		require.NoError(t, err)
+		assert.Equal(t, int32(5), profile.ID)
+		assert.Equal(t, "High Definition", profile.Name)
+		assert.Equal(t, int32(23), profile.CutoffQualityID)
+		assert.Equal(t, true, profile.UpgradeAllowed)
+		assert.Equal(t, "Remux-1080p", profile.Qualities[0].Name)
+		assert.Equal(t, float64(1999), profile.Qualities[0].PreferredSize)
+		assert.Equal(t, float64(4.5), profile.Qualities[0].MinSize)
+		assert.Equal(t, float64(12.0), profile.Qualities[0].MaxSize)
+		assert.Equal(t, "episode", profile.Qualities[0].MediaType)
+	})
+}
+
+func TestMediaManager_ListMovieQualityProfiles(t *testing.T) {
+	t.Run("list movie quality profiles", func(t *testing.T) {
+		ctx := context.Background()
+		store, err := mediaSqlite.New(":memory:")
+		require.NoError(t, err)
+
+		schemas, err := storage.ReadSchemaFiles("../storage/sqlite/schema/schema.sql", "../storage/sqlite/schema/defaults.sql")
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		err = store.Init(ctx, schemas...)
+		require.NoError(t, err)
+
+		manager := MediaManager{
+			storage: store,
+		}
+
+		profile, err := manager.ListMovieQualityProfiles(ctx, 1)
+		require.NoError(t, err)
+		require.Len(t, profile, 3)
+		assert.Equal(t, int32(3), profile[0].ID)
+		assert.Equal(t, "Ultra High Definition", profile[0].Name)
+		assert.Equal(t, int32(13), profile[0].CutoffQualityID)
+		assert.Equal(t, int32(2), profile[1].ID)
+		assert.Equal(t, "High Definition", profile[1].Name)
+		assert.Equal(t, int32(8), profile[1].CutoffQualityID)
+		assert.Equal(t, int32(2), profile[1].ID)
+		assert.Equal(t, "Standard Definition", profile[2].Name)
+		assert.Equal(t, int32(1), profile[2].ID)
+		assert.Equal(t, int32(2), profile[2].CutoffQualityID)
+	})
+}
+
+func TestMediaManager_ListEpisodeQualityProfiles(t *testing.T) {
+	t.Run("list episode quality profiles", func(t *testing.T) {
+		ctx := context.Background()
+		store, err := mediaSqlite.New(":memory:")
+		require.NoError(t, err)
+
+		schemas, err := storage.ReadSchemaFiles("../storage/sqlite/schema/schema.sql", "../storage/sqlite/schema/defaults.sql")
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		err = store.Init(ctx, schemas...)
+		require.NoError(t, err)
+
+		manager := MediaManager{
+			storage: store,
+		}
+
+		profile, err := manager.ListEpisodeQualityProfiles(ctx, 1)
+		require.NoError(t, err)
+		require.Len(t, profile, 3)
+
+		assert.Equal(t, "Ultra High Definition", profile[0].Name)
+		assert.Equal(t, int32(6), profile[0].ID)
+		assert.Equal(t, int32(27), profile[0].CutoffQualityID)
+
+		assert.Equal(t, "High Definition", profile[1].Name)
+		assert.Equal(t, int32(5), profile[1].ID)
+		assert.Equal(t, int32(23), profile[1].CutoffQualityID)
+
+		assert.Equal(t, "Standard Definition", profile[2].Name)
+		assert.Equal(t, int32(4), profile[2].ID)
+		assert.Equal(t, int32(16), profile[2].CutoffQualityID)
+	})
 }

--- a/pkg/manager/reconcile.go
+++ b/pkg/manager/reconcile.go
@@ -283,7 +283,7 @@ func (m MediaManager) reconcileMissingMovie(ctx context.Context, movie *storage.
 		return err
 	}
 
-	profile, err := m.storage.GetQualityProfile(ctx, int64(movie.QualityProfileID))
+	profile, err := m.GetQualityProfile(ctx, int64(movie.QualityProfileID))
 	if err != nil {
 		log.Warnw("failed to find movie qualityprofile", "quality_id", movie.QualityProfileID)
 		return err

--- a/pkg/storage/mocks/mock_storage.go
+++ b/pkg/storage/mocks/mock_storage.go
@@ -238,18 +238,18 @@ func (mr *MockStorageMockRecorder) CreateSeasonMetadata(ctx, seasonMeta any) *go
 }
 
 // CreateSeries mocks base method.
-func (m *MockStorage) CreateSeries(ctx context.Context, Series storage.Series, initialState storage.SeriesState) (int64, error) {
+func (m *MockStorage) CreateSeries(ctx context.Context, series storage.Series, initialState storage.SeriesState) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSeries", ctx, Series, initialState)
+	ret := m.ctrl.Call(m, "CreateSeries", ctx, series, initialState)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSeries indicates an expected call of CreateSeries.
-func (mr *MockStorageMockRecorder) CreateSeries(ctx, Series, initialState any) *gomock.Call {
+func (mr *MockStorageMockRecorder) CreateSeries(ctx, series, initialState any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSeries", reflect.TypeOf((*MockStorage)(nil).CreateSeries), ctx, Series, initialState)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSeries", reflect.TypeOf((*MockStorage)(nil).CreateSeries), ctx, series, initialState)
 }
 
 // CreateSeriesMetadata mocks base method.
@@ -942,18 +942,23 @@ func (mr *MockStorageMockRecorder) ListQualityProfileItems(ctx any) *gomock.Call
 }
 
 // ListQualityProfiles mocks base method.
-func (m *MockStorage) ListQualityProfiles(ctx context.Context) ([]*storage.QualityProfile, error) {
+func (m *MockStorage) ListQualityProfiles(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.QualityProfile, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListQualityProfiles", ctx)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListQualityProfiles", varargs...)
 	ret0, _ := ret[0].([]*storage.QualityProfile)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListQualityProfiles indicates an expected call of ListQualityProfiles.
-func (mr *MockStorageMockRecorder) ListQualityProfiles(ctx any) *gomock.Call {
+func (mr *MockStorageMockRecorder) ListQualityProfiles(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListQualityProfiles", reflect.TypeOf((*MockStorage)(nil).ListQualityProfiles), ctx)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListQualityProfiles", reflect.TypeOf((*MockStorage)(nil).ListQualityProfiles), varargs...)
 }
 
 // ListSeasonMetadata mocks base method.
@@ -1331,18 +1336,23 @@ func (mr *MockQualityStorageMockRecorder) ListQualityProfileItems(ctx any) *gomo
 }
 
 // ListQualityProfiles mocks base method.
-func (m *MockQualityStorage) ListQualityProfiles(ctx context.Context) ([]*storage.QualityProfile, error) {
+func (m *MockQualityStorage) ListQualityProfiles(ctx context.Context, where ...sqlite.BoolExpression) ([]*storage.QualityProfile, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListQualityProfiles", ctx)
+	varargs := []any{ctx}
+	for _, a := range where {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListQualityProfiles", varargs...)
 	ret0, _ := ret[0].([]*storage.QualityProfile)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListQualityProfiles indicates an expected call of ListQualityProfiles.
-func (mr *MockQualityStorageMockRecorder) ListQualityProfiles(ctx any) *gomock.Call {
+func (mr *MockQualityStorageMockRecorder) ListQualityProfiles(ctx any, where ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListQualityProfiles", reflect.TypeOf((*MockQualityStorage)(nil).ListQualityProfiles), ctx)
+	varargs := append([]any{ctx}, where...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListQualityProfiles", reflect.TypeOf((*MockQualityStorage)(nil).ListQualityProfiles), varargs...)
 }
 
 // MockMovieStorage is a mock of MovieStorage interface.
@@ -1807,18 +1817,18 @@ func (mr *MockSeriesStorageMockRecorder) CreateSeason(ctx, season, initialState 
 }
 
 // CreateSeries mocks base method.
-func (m *MockSeriesStorage) CreateSeries(ctx context.Context, Series storage.Series, initialState storage.SeriesState) (int64, error) {
+func (m *MockSeriesStorage) CreateSeries(ctx context.Context, series storage.Series, initialState storage.SeriesState) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSeries", ctx, Series, initialState)
+	ret := m.ctrl.Call(m, "CreateSeries", ctx, series, initialState)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSeries indicates an expected call of CreateSeries.
-func (mr *MockSeriesStorageMockRecorder) CreateSeries(ctx, Series, initialState any) *gomock.Call {
+func (mr *MockSeriesStorageMockRecorder) CreateSeries(ctx, series, initialState any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSeries", reflect.TypeOf((*MockSeriesStorage)(nil).CreateSeries), ctx, Series, initialState)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSeries", reflect.TypeOf((*MockSeriesStorage)(nil).CreateSeries), ctx, series, initialState)
 }
 
 // DeleteEpisode mocks base method.

--- a/pkg/storage/sqlite/schema/defaults.sql
+++ b/pkg/storage/sqlite/schema/defaults.sql
@@ -1,4 +1,4 @@
--- Inserting into the quality_definition table
+-- Quality Definitions for Movies
 INSERT INTO
     quality_definition (
         quality_id,
@@ -24,40 +24,81 @@ VALUES
     (13, 'Bluray-2160p', 1999, 102, 2000, 'movie'),
     (14, 'Remux-2160p', 1999, 187.4, 2000, 'movie');
 
+-- Quality Definitions for Episodes
 INSERT INTO
-    "quality_profile" ("name", "cutoff_quality_id", "upgrade_allowed")
+    quality_definition (
+        quality_id,
+        name,
+        preferred_size,
+        min_size,
+        max_size,
+        media_type
+    )
 VALUES
-    ('Standard Definition', 2, TRUE),
-    ('High Definition', 8, TRUE),
-    ('Ultra High Definition', 13, FALSE);
+    (15, 'HDTV-720p', 1999, 0.7, 2.5, 'episode'),
+    (16, 'WEBDL-720p', 1999, 0.6, 2.2, 'episode'),
+    (17, 'WEBRip-720p', 1999, 0.6, 2.2, 'episode'),
+    (18, 'Bluray-720p', 1999, 1.2, 3.5, 'episode'),
+    (19, 'HDTV-1080p', 1999, 1.8, 5.0, 'episode'),
+    (20, 'WEBDL-1080p', 1999, 1.4, 4.0, 'episode'),
+    (21, 'WEBRip-1080p', 1999, 1.4, 4.0, 'episode'),
+    (22, 'Bluray-1080p', 1999, 2.5, 6.0, 'episode'),
+    (23, 'Remux-1080p', 1999, 4.5, 12.0, 'episode'),
+    (24, 'HDTV-2160p', 1999, 6.0, 15.0, 'episode'),
+    (25, 'WEBDL-2160p', 1999, 4.0, 10.0, 'episode'),
+    (26, 'WEBRip-2160p', 1999, 4.0, 10.0, 'episode'),
+    (27, 'Bluray-2160p', 1999, 6.0, 15.0, 'episode'),
+    (28, 'Remux-2160p', 1999, 8.0, 25.0, 'episode');
 
--- Inserting into the quality_profile_item table
+-- Movie Profiles
 INSERT INTO
-    "quality_profile_item" ("profile_id", "quality_id")
+    quality_profile (id, name, cutoff_quality_id, upgrade_allowed)
 VALUES
-    -- Standard Definition includes SDTV
+    (1, 'Standard Definition', 2, TRUE),
+    (2, 'High Definition', 8, TRUE),
+    (3, 'Ultra High Definition', 13, FALSE);
+
+-- Movie Profile Items
+INSERT INTO
+    quality_profile_item (profile_id, quality_id)
+VALUES
     (1, 1),
-    -- Standard Definition includes DVD
     (1, 2),
-    -- High Definition includes HDTV-720p
     (2, 3),
-    -- High Definition includes WEBDL-720p
     (2, 4),
-    -- High Definition includes Bluray-720p
     (2, 5),
-    -- High Definition includes HDTV-1080p
     (2, 6),
-    -- High Definition includes WEBDL-1080p
     (2, 7),
-    -- High Definition includes Bluray-1080p
     (2, 8),
-    -- Ultra High Definition includes Remux-1080p
     (3, 9),
-    -- Ultra High Definition includes HDTV-2160p
     (3, 10),
-    -- Ultra High Definition includes WEBDL-2160p
     (3, 11),
-    -- Ultra High Definition includes Bluray-2160p
     (3, 12),
-    -- Ultra High Definition includes Remux-2160p
     (3, 13);
+
+-- Episode Profiles
+INSERT INTO
+    quality_profile (id, name, cutoff_quality_id, upgrade_allowed)
+VALUES
+    (4, 'Standard Definition', 16, TRUE),
+    (5, 'High Definition', 23, TRUE),
+    (6, 'Ultra High Definition', 27, FALSE);
+
+-- Episode Profile Items
+INSERT INTO
+    quality_profile_item (profile_id, quality_id)
+VALUES
+    (4, 15),
+    (4, 16),
+    (5, 17),
+    (5, 18),
+    (5, 19),
+    (5, 20),
+    (5, 21),
+    (5, 22),
+    (5, 23),
+    (6, 23),
+    (6, 24),
+    (6, 25),
+    (6, 26),
+    (6, 27);

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -32,7 +32,7 @@ type IndexerStorage interface {
 type QualityStorage interface {
 	CreateQualityProfile(ctx context.Context, profile model.QualityProfile) (int64, error)
 	GetQualityProfile(ctx context.Context, id int64) (QualityProfile, error)
-	ListQualityProfiles(ctx context.Context) ([]*QualityProfile, error)
+	ListQualityProfiles(ctx context.Context, where ...sqlite.BoolExpression) ([]*QualityProfile, error)
 	DeleteQualityProfile(ctx context.Context, id int64) error //TODO: do we cascade associated items?
 
 	CreateQualityProfileItem(ctx context.Context, item model.QualityProfileItem) (int64, error)


### PR DESCRIPTION
Adding quality profiles for episodes. My thoughts were that depending on the media you were querying for we would pull profiles for it (movie vs episode), and then let you pick from those. We then use that id when adding the media to be owned by the manager.

AI gave me the sizes for the episodes, I have no idea how accurate they are for those definitions, open to change them