### PR TITLE
Add tv show detail endpoint

### DIFF
--- a/pkg/manager/metadata.go
+++ b/pkg/manager/metadata.go
@@ -230,6 +230,9 @@ func FromSeriesEpisodes(episode tmdb.Episode) model.EpisodeMetadata {
 }
 
 func parseTMDBDate(date string) (*time.Time, error) {
+	if date == "" {
+		return nil, nil
+	}
 	t, err := time.Parse(tmdb.ReleaseDateFormat, date)
 	if err != nil {
 		return nil, err

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -218,6 +220,219 @@ func TestServer_GetMovieDetailByTMDBID(t *testing.T) {
 
 		router := mux.NewRouter()
 		router.HandleFunc("/movie/{tmdbID}", s.GetMovieDetailByTMDBID()).Methods("GET")
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("content-type"))
+
+		// For error responses, we just check that it's a proper error response
+		responseBody := rr.Body.String()
+		assert.Contains(t, responseBody, "error")
+		assert.Contains(t, responseBody, "null") // response should be null when there's an error
+	})
+}
+
+func TestServer_GetTVDetailByTMDBID(t *testing.T) {
+	t.Run("success - TV show exists in library", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// Mock storage
+		store := storeMocks.NewMockStorage(ctrl)
+		
+		// Mock TMDB client
+		tmdbMock := tmdbMocks.NewMockITmdb(ctrl)
+
+		// Setup expectations for GetSeriesMetadata call
+		expectedMetadata := &model.SeriesMetadata{
+			ID:           1,
+			TmdbID:       12345,
+			Title:        "Test TV Show",
+			Overview:     ptr("A test TV show overview"),
+			FirstAirDate: ptr(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)),
+			LastAirDate:  ptr(time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)),
+			SeasonCount:  3,
+			EpisodeCount: 30,
+		}
+
+		store.EXPECT().GetSeriesMetadata(gomock.Any(), gomock.Any()).Return(expectedMetadata, nil)
+
+		// Setup expectations for TvSeriesDetails call
+		responseBody := `{
+			"poster_path": "/test-poster.jpg",
+			"backdrop_path": "/test-backdrop.jpg",
+			"adult": true,
+			"popularity": 85.5,
+			"networks": [{"name": "HBO"}, {"name": "Netflix"}],
+			"genres": [{"name": "Drama"}, {"name": "Thriller"}]
+		}`
+		resp := &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+		}
+		tmdbMock.EXPECT().TvSeriesDetails(gomock.Any(), int32(12345), nil).Return(resp, nil)
+
+		// Setup expectations for GetSeries call
+		expectedSeries := &storage.Series{
+			Series: model.Series{
+				ID:               1,
+				SeriesMetadataID: ptr(int32(1)),
+				QualityProfileID: 1,
+				Monitored:        1,
+				Path:             ptr("/tv/Test TV Show (2023)"),
+			},
+			State: storage.SeriesStateDiscovered,
+		}
+
+		store.EXPECT().GetSeries(gomock.Any(), gomock.Any()).Return(expectedSeries, nil)
+
+		// Create manager with mocked dependencies
+		mgr := manager.New(tmdbMock, nil, nil, store, nil, config.Manager{})
+
+		s := Server{
+			baseLogger: zap.NewNop().Sugar(),
+			manager:    mgr,
+		}
+
+		req, err := http.NewRequest("GET", "/tv/12345", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		router := mux.NewRouter()
+		router.HandleFunc("/tv/{tmdbID}", s.GetTVDetailByTMDBID()).Methods("GET")
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("content-type"))
+
+		var response GenericResponse
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		tvDetail, ok := response.Response.(map[string]interface{})
+		require.True(t, ok, "Response should be a map")
+
+		assert.Equal(t, float64(12345), tvDetail["tmdbID"])
+		assert.Equal(t, "Test TV Show", tvDetail["title"])
+		assert.Equal(t, "A test TV show overview", tvDetail["overview"])
+		assert.Equal(t, "/test-poster.jpg", tvDetail["posterPath"])
+		assert.Equal(t, "/test-backdrop.jpg", tvDetail["backdropPath"])
+		assert.Equal(t, "2023-01-01", tvDetail["firstAirDate"])
+		assert.Equal(t, "2023-12-31", tvDetail["lastAirDate"])
+		assert.Equal(t, float64(3), tvDetail["seasonCount"])
+		assert.Equal(t, float64(30), tvDetail["episodeCount"])
+		
+		// Check networks array
+		networks, ok := tvDetail["networks"].([]interface{})
+		require.True(t, ok)
+		assert.Equal(t, []interface{}{"HBO", "Netflix"}, networks)
+		
+		// Check genres array
+		genres, ok := tvDetail["genres"].([]interface{})
+		require.True(t, ok)
+		assert.Equal(t, []interface{}{"Drama", "Thriller"}, genres)
+		
+		assert.Equal(t, "discovered", tvDetail["libraryStatus"])
+		assert.Equal(t, "/tv/Test TV Show (2023)", tvDetail["path"])
+		assert.Equal(t, true, tvDetail["monitored"])
+	})
+
+	t.Run("success - TV show not in library", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		store := storeMocks.NewMockStorage(ctrl)
+		tmdbMock := tmdbMocks.NewMockITmdb(ctrl)
+
+		expectedMetadata := &model.SeriesMetadata{
+			ID:           1,
+			TmdbID:       12345,
+			Title:        "Test TV Show",
+			SeasonCount:  2,
+			EpisodeCount: 20,
+		}
+
+		store.EXPECT().GetSeriesMetadata(gomock.Any(), gomock.Any()).Return(expectedMetadata, nil)
+
+		responseBody := `{"poster_path": "/test-poster.jpg"}`
+		resp := &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+		}
+		tmdbMock.EXPECT().TvSeriesDetails(gomock.Any(), int32(12345), nil).Return(resp, nil)
+
+		store.EXPECT().GetSeries(gomock.Any(), gomock.Any()).Return(nil, storage.ErrNotFound)
+
+		mgr := manager.New(tmdbMock, nil, nil, store, nil, config.Manager{})
+
+		s := Server{
+			baseLogger: zap.NewNop().Sugar(),
+			manager:    mgr,
+		}
+
+		req, err := http.NewRequest("GET", "/tv/12345", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		router := mux.NewRouter()
+		router.HandleFunc("/tv/{tmdbID}", s.GetTVDetailByTMDBID()).Methods("GET")
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response GenericResponse
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		tvDetail, ok := response.Response.(map[string]interface{})
+		require.True(t, ok, "Response should be a map")
+
+		assert.Equal(t, "Not In Library", tvDetail["libraryStatus"])
+		assert.Nil(t, tvDetail["path"])
+		assert.Nil(t, tvDetail["monitored"])
+	})
+
+	t.Run("invalid tmdb id format", func(t *testing.T) {
+		s := Server{baseLogger: zap.NewNop().Sugar()}
+
+		req, err := http.NewRequest("GET", "/tv/invalid", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		router := mux.NewRouter()
+		router.HandleFunc("/tv/{tmdbID}", s.GetTVDetailByTMDBID()).Methods("GET")
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Contains(t, rr.Body.String(), "Invalid TMDB ID format")
+	})
+
+	t.Run("manager error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		store := storeMocks.NewMockStorage(ctrl)
+		tmdbMock := tmdbMocks.NewMockITmdb(ctrl)
+
+		store.EXPECT().GetSeriesMetadata(gomock.Any(), gomock.Any()).Return(nil, errors.New("metadata not found"))
+
+		mgr := manager.New(tmdbMock, nil, nil, store, nil, config.Manager{})
+
+		s := Server{
+			baseLogger: zap.NewNop().Sugar(),
+			manager:    mgr,
+		}
+
+		req, err := http.NewRequest("GET", "/tv/12345", nil)
+		require.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+
+		router := mux.NewRouter()
+		router.HandleFunc("/tv/{tmdbID}", s.GetTVDetailByTMDBID()).Methods("GET")
 		router.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)


### PR DESCRIPTION
towards #45 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add endpoint to retrieve detailed TV show information by TMDB ID, including data handling and tests.
> 
>   - **Behavior**:
>     - Adds `GetTVDetailByTMDBID` function in `manager.go` to retrieve TV show details by TMDB ID.
>     - Adds `/tv/{tmdbID}` endpoint in `server.go` to expose TV show details via HTTP GET.
>   - **Data Handling**:
>     - Introduces `TVDetailResult` struct in `manager.go` for TV show details.
>     - Implements `getTVMetadataAndDetails` and `buildTVDetailResult` in `manager.go` for data retrieval and transformation.
>   - **Testing**:
>     - Adds `TestGetTVDetailByTMDBID` and `TestBuildTVDetailResult` in `manager_test.go` for unit testing.
>     - Adds `TestServer_GetTVDetailByTMDBID` in `server_test.go` for endpoint testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kasuboski%2Fmediaz&utm_source=github&utm_medium=referral)<sup> for c9afdee6f6506197b7755ce986021438bfc20101. You can [customize](https://app.ellipsis.dev/kasuboski/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->