### PR TITLE
Handle more title possibilities

### DIFF
--- a/pkg/manager/release.go
+++ b/pkg/manager/release.go
@@ -512,9 +512,33 @@ func pathToSearchTerm(path string) string {
 		return ""
 	}
 
-	// Match (YYYY) pattern but not if it's inside another parentheses
-	yearRegex := regexp.MustCompile(`\s*\((?:\d{4})\)(?:\s*$|\s+)`)
-	return strings.TrimSpace(yearRegex.ReplaceAllString(path, ""))
+	// Replace dots with spaces (for movie.name.format)
+	cleaned := strings.ReplaceAll(path, ".", " ")
+
+	// Remove release group indicators (e.g., -EVO[EtHD])
+	releaseRegex := regexp.MustCompile(`-[A-Z0-9]+\[[^\]]+\]`)
+	cleaned = releaseRegex.ReplaceAllString(cleaned, "")
+
+	// Remove years in various formats: (YYYY), {YYYY}, [YYYY], or trailing YYYY
+	yearRegex := regexp.MustCompile(`\s*[\(\[\{]?(19|20)\d{2}[\)\]\}]?(?:\s|$)`)
+	cleaned = yearRegex.ReplaceAllString(cleaned, " ")
+
+	// Remove common quality indicators
+	qualityRegex := regexp.MustCompile(`(?i)\b(720p|1080p|4k|2160p|x264|h264|hevc|web-dl|bluray|dvdrip|cam|ts|tc)\b`)
+	cleaned = qualityRegex.ReplaceAllString(cleaned, "")
+
+	// Remove codec and audio info
+	codecRegex := regexp.MustCompile(`(?i)\b(h264|ac3|aac|dts|dd5\.1)\b`)
+	cleaned = codecRegex.ReplaceAllString(cleaned, "")
+
+	// Remove empty brackets and parentheses
+	emptyBracketsRegex := regexp.MustCompile(`\s*[\[\(\{][\]\)\}]\s*`)
+	cleaned = emptyBracketsRegex.ReplaceAllString(cleaned, " ")
+
+	// Clean up multiple spaces
+	cleaned = regexp.MustCompile(`\s+`).ReplaceAllString(cleaned, " ")
+
+	return strings.TrimSpace(cleaned)
 }
 
 func removeFromName(filename string, toRemove ...string) string {

--- a/pkg/manager/release_test.go
+++ b/pkg/manager/release_test.go
@@ -232,6 +232,37 @@ func TestPathToSearchTerm(t *testing.T) {
 			path: "",
 			want: "",
 		},
+		// Failing test cases from the issue
+		{
+			name: "year in curly braces",
+			path: "Apocalypse Now {1979}",
+			want: "Apocalypse Now",
+		},
+		{
+			name: "dotted filename with year and quality tags",
+			path: "Columbus.2017.1080p.WEB-DL.H264.AC3-EVO[EtHD]",
+			want: "Columbus",
+		},
+		{
+			name: "year at end without parentheses",
+			path: "Der Untergang - Downfall 2004",
+			want: "Der Untergang - Downfall",
+		},
+		{
+			name: "year in parentheses with quality",
+			path: "Hugo (2011) 720p",
+			want: "Hugo",
+		},
+		{
+			name: "year in parentheses with quality in brackets",
+			path: "Hunt for the Wilderpeople (2016) [1080p]",
+			want: "Hunt for the Wilderpeople",
+		},
+		{
+			name: "year in square brackets",
+			path: "Guardians of the Galaxy [2014] 1080p",
+			want: "Guardians of the Galaxy",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `pathToSearchTerm` in `release.go` to handle more title patterns and update tests in `release_test.go`.
> 
>   - **Enhancements in `release.go`**:
>     - `pathToSearchTerm` function now removes release group indicators, years in various formats, quality indicators, codec and audio info, empty brackets, and multiple spaces.
>     - Added regex patterns for release groups, years, quality, codecs, empty brackets, and multiple spaces.
>   - **Test Updates in `release_test.go`**:
>     - Added test cases for `pathToSearchTerm` to cover new patterns like years in curly braces, dotted filenames, and quality tags.
>     - Updated existing test cases to ensure compatibility with new regex patterns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kasuboski%2Fmediaz&utm_source=github&utm_medium=referral)<sup> for 41f357b53fb476b1477c0bacd3dd5f3be9abb1e6. You can [customize](https://app.ellipsis.dev/kasuboski/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->