### PR TITLE
Feature/setup backend frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-alpine AS frontend-builder
+WORKDIR /app/frontend
+COPY frontend/package.json frontend/package-lock.json* ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
+FROM golang:1.24-alpine AS backend-builder
+RUN apk add --no-cache gcc musl-dev
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=1 go build -o mediaz main.go
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=backend-builder /app/mediaz .
+COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
+CMD ["./mediaz", "serve"]

--- a/cmd/indexer.go
+++ b/cmd/indexer.go
@@ -135,7 +135,7 @@ var searchIndexerCmd = &cobra.Command{
 
 		schemas, err := storage.GetSchemas()
 		if err != nil {
-			log.Fatal("failed to read embedded schema files", zap.Error(err))
+			log.Fatal("failed to read schema files", zap.Error(err))
 		}
 
 		err = store.Init(context.TODO(), schemas...)

--- a/cmd/indexer.go
+++ b/cmd/indexer.go
@@ -133,9 +133,9 @@ var searchIndexerCmd = &cobra.Command{
 			log.Fatal("failed to create storage connection", zap.Error(err))
 		}
 
-		schemas, err := storage.ReadSchemaFiles(defaultSchemas...)
+		schemas, err := storage.GetSchemas()
 		if err != nil {
-			log.Fatal("failed to read schema files", zap.Error(err))
+			log.Fatal("failed to read embedded schema files", zap.Error(err))
 		}
 
 		err = store.Init(context.TODO(), schemas...)

--- a/cmd/indexer.go
+++ b/cmd/indexer.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/url"
 	"os"
 
 	"github.com/dustin/go-humanize"
@@ -37,12 +36,7 @@ var listIndexerCmd = &cobra.Command{
 			log.Fatalf("failed to read configurations: %v", err)
 		}
 
-		u := url.URL{
-			Scheme: cfg.Prowlarr.Scheme,
-			Host:   cfg.Prowlarr.Host,
-		}
-
-		c, err := prowlarr.NewClient(u.String(), prowlarr.WithRequestEditorFn(prowlarr.SetRequestAPIKey((cfg.Prowlarr.APIKey))))
+		c, err := prowlarr.NewClient(cfg.Prowlarr.URI, prowlarr.WithRequestEditorFn(prowlarr.SetRequestAPIKey((cfg.Prowlarr.APIKey))))
 		if err != nil {
 			log.Fatalf("failed to create client: %v", err)
 		}
@@ -86,22 +80,12 @@ var searchIndexerCmd = &cobra.Command{
 			log.Fatalf("failed to read configurations: %v", err)
 		}
 
-		u := url.URL{
-			Scheme: cfg.Prowlarr.Scheme,
-			Host:   cfg.Prowlarr.Host,
-		}
-
-		prowlarrClient, err := prowlarr.New(u.String(), cfg.Prowlarr.APIKey)
+		prowlarrClient, err := prowlarr.New(cfg.Prowlarr.URI, cfg.Prowlarr.APIKey)
 		if err != nil {
 			log.Fatalf("failed to create client: %v", err)
 		}
 
-		tmdbURL := url.URL{
-			Scheme: cfg.TMDB.Scheme,
-			Host:   cfg.TMDB.Host,
-		}
-
-		tmdbClient, err := tmdb.New(tmdbURL.String(), cfg.TMDB.APIKey)
+		tmdbClient, err := tmdb.New(cfg.TMDB.URI, cfg.TMDB.APIKey)
 		if err != nil {
 			log.Fatal("failed to create tmdb client", err)
 		}

--- a/cmd/movie.go
+++ b/cmd/movie.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"log"
-	"net/url"
 	"os"
 
 	"github.com/kasuboski/mediaz/config"
@@ -31,12 +30,7 @@ var discoverMovieCmd = &cobra.Command{
 			log.Fatalf("failed to read configurations: %v", err)
 		}
 
-		u := url.URL{
-			Scheme: cfg.TMDB.Scheme,
-			Host:   cfg.TMDB.Host,
-		}
-
-		c, err := tmdb.NewClient(u.String(), tmdb.WithHTTPClient(mhttp.NewRateLimitedClient()))
+		c, err := tmdb.NewClient(cfg.TMDB.URI, tmdb.WithHTTPClient(mhttp.NewRateLimitedClient()))
 		if err != nil {
 			log.Fatalf("failed to create tmdb client: %v", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,12 +47,10 @@ func initConfig() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", ""))
 	viper.AutomaticEnv()
 
-	viper.SetDefault("tmdb.scheme", "https")
-	viper.SetDefault("tmdb.host", "api.themoviedb.org")
+	viper.SetDefault("tmdb.uri", "https://api.themoviedb.org")
 	viper.SetDefault("tmdb.apiKey", "")
 
-	viper.SetDefault("prowlarr.scheme", "")
-	viper.SetDefault("prowlarr.host", "")
+	viper.SetDefault("prowlarr.uri", "")
 	viper.SetDefault("prowlarr.apiKey", "")
 
 	viper.SetDefault("server.port", 8080)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func initConfig() {
 	viper.SetDefault("prowlarr.apiKey", "")
 
 	viper.SetDefault("server.port", 8080)
-	viper.SetDefault("server.staticAssetsDir", "./frontend/dist")
+	viper.SetDefault("server.distDir", "./frontend/dist")
 
 	viper.SetDefault("library.tv", "")
 	viper.SetDefault("library.movie", "")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,7 @@ func initConfig() {
 	viper.SetDefault("prowlarr.apiKey", "")
 
 	viper.SetDefault("server.port", 8080)
+	viper.SetDefault("server.staticAssetsDir", "./frontend/dist")
 
 	viper.SetDefault("library.tv", "")
 	viper.SetDefault("library.movie", "")

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -23,7 +23,7 @@ var schemaCmd = &cobra.Command{
 	Short: "generate database code",
 	Long:  `generate database code`,
 	Run: func(cmd *cobra.Command, args []string) {
-		schemas, err := storage.ReadSchemaFiles(schemaFiles...)
+		schemas, err := storage.GetSchemas()
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -103,7 +103,7 @@ var serveCmd = &cobra.Command{
 			log.Fatal(manager.Run(context.Background()))
 		}()
 
-		server := server.New(log, manager)
+		server := server.New(log, manager, &cfg.Server)
 		log.Error(server.Serve(cfg.Server.Port))
 	},
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"net/url"
 	"os"
 
 	"github.com/kasuboski/mediaz/config"
@@ -38,25 +37,15 @@ var serveCmd = &cobra.Command{
 			log.Fatal("failed to read configurations", zap.Error(err))
 		}
 
-		tmdbURL := url.URL{
-			Scheme: cfg.TMDB.Scheme,
-			Host:   cfg.TMDB.Host,
-		}
-
 		tmdbHttpClient := mhttp.NewRateLimitedClient()
-		tmdbClient, err := tmdb.New(tmdbURL.String(), cfg.TMDB.APIKey, tmdb.WithHTTPClient(tmdbHttpClient))
+		tmdbClient, err := tmdb.New(cfg.TMDB.URI, cfg.TMDB.APIKey, tmdb.WithHTTPClient(tmdbHttpClient))
 		if err != nil {
 			log.Fatal("failed to create tmdb client", zap.Error(err))
 		}
 
-		prowlarrURL := url.URL{
-			Scheme: cfg.Prowlarr.Scheme,
-			Host:   cfg.Prowlarr.Host,
-		}
-
-		prowlarrClient, err := prowlarr.New(prowlarrURL.String(), cfg.Prowlarr.APIKey)
+		prowlarrClient, err := prowlarr.New(cfg.Prowlarr.URI, cfg.Prowlarr.APIKey)
 		if err != nil {
-			log.Fatal("failed to create prowlarr client", zap.Error(err))
+			log.Fatal("failed to create client", zap.Error(err))
 		}
 
 		defaultSchemas := cfg.Storage.Schemas

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -72,9 +72,9 @@ var serveCmd = &cobra.Command{
 			log.Fatal("failed to create storage connection", zap.Error(err))
 		}
 
-		schemas, err := storage.ReadSchemaFiles(defaultSchemas...)
+		schemas, err := storage.GetSchemas()
 		if err != nil {
-			log.Fatal("failed to read schema files", zap.Error(err))
+			log.Fatal("failed to read embedded schema files", zap.Error(err))
 		}
 
 		err = store.Init(context.TODO(), schemas...)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -74,7 +74,7 @@ var serveCmd = &cobra.Command{
 
 		schemas, err := storage.GetSchemas()
 		if err != nil {
-			log.Fatal("failed to read embedded schema files", zap.Error(err))
+			log.Fatal("failed to read schema files", zap.Error(err))
 		}
 
 		err = store.Init(context.TODO(), schemas...)

--- a/cmd/tv.go
+++ b/cmd/tv.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"net/url"
 	"os"
 
 	"github.com/kasuboski/mediaz/config"
@@ -68,13 +67,8 @@ var seriesDetailsCmd = &cobra.Command{
 			log.Fatal("failed to read configurations", zap.Error(err))
 		}
 
-		tmdbURL := url.URL{
-			Scheme: cfg.TMDB.Scheme,
-			Host:   cfg.TMDB.Host,
-		}
-
 		tmdbHttpClient := mhttp.NewRateLimitedClient()
-		tmdbClient, err := tmdb.New(tmdbURL.String(), cfg.TMDB.APIKey, tmdb.WithHTTPClient(tmdbHttpClient))
+		tmdbClient, err := tmdb.New(cfg.TMDB.URI, cfg.TMDB.APIKey, tmdb.WithHTTPClient(tmdbHttpClient))
 		if err != nil {
 			log.Fatal("failed to create tmdb client", zap.Error(err))
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,8 @@ type TMDB struct {
 }
 
 type Server struct {
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
+	Port            int    `json:"port" yaml:"port" mapstructure:"port"`
+	StaticAssetsDir string `json:"staticAssetsDir" yaml:"staticAssetsDir" mapstructure:"staticAssetsDir"`
 }
 
 type Library struct {

--- a/config/config.go
+++ b/config/config.go
@@ -23,8 +23,8 @@ type TMDB struct {
 }
 
 type Server struct {
-	Port            int    `json:"port" yaml:"port" mapstructure:"port"`
-	StaticAssetsDir string `json:"staticAssetsDir" yaml:"staticAssetsDir" mapstructure:"staticAssetsDir"`
+	Port    int    `json:"port" yaml:"port" mapstructure:"port"`
+	DistDir string `json:"distDir" yaml:"distDir" mapstructure:"distDir"`
 }
 
 type Library struct {

--- a/config/config.go
+++ b/config/config.go
@@ -16,8 +16,7 @@ type Config struct {
 }
 
 type TMDB struct {
-	Scheme      string        `json:"scheme" yaml:"scheme" mapstructure:"scheme"`
-	Host        string        `json:"host" yaml:"host" mapstructure:"host"`
+	URI         string        `json:"uri" yaml:"uri" mapstructure:"uri"`
 	APIKey      string        `json:"apiKey" yaml:"apiKey" mapstructure:"apiKey"`
 	BaseBackoff time.Duration `json:"backoff" yaml:"backoff" mapstructure:"backoff"`
 	MaxRetries  int           `json:"maxRetries" yaml:"maxRetries" mapstructure:"maxRetries"`
@@ -35,8 +34,7 @@ type Library struct {
 }
 
 type Prowlarr struct {
-	Scheme string `json:"scheme" yaml:"scheme" mapstructure:"scheme"`
-	Host   string `json:"host" yaml:"host" mapstructure:"host"`
+	URI    string `json:"uri" yaml:"uri" mapstructure:"uri"`
 	APIKey string `json:"apiKey" yaml:"apiKey" mapstructure:"apiKey"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,13 +40,11 @@ func TestNew(t *testing.T) {
 
 		wantConfig := Config{
 			TMDB: TMDB{
-				Scheme: "https",
-				Host:   "my-host",
+				URI:    "https://my-host",
 				APIKey: "my-api-key",
 			},
 			Prowlarr: Prowlarr{
-				Scheme: "https",
-				Host:   "my-prowlarr-host",
+				URI:    "https://my-prowlarr-host",
 				APIKey: "my-prowlarr-api-key",
 			},
 			Manager: Manager{
@@ -65,9 +63,9 @@ func TestNew(t *testing.T) {
 	t.Run("success without file", func(t *testing.T) {
 		cu := viper.New()
 		cu.SetConfigFile("")
-		cu.SetDefault("tmdb.scheme", "https")
+		cu.SetDefault("tmdb.uri", "https://api.themoviedb.org")
 		cu.SetDefault("tmdb.apiKey", "fake-key")
-		cu.SetDefault("prowlarr.scheme", "http")
+		cu.SetDefault("prowlarr.uri", "http://localhost")
 		cu.SetDefault("manager.jobs.movieIndex", time.Minute*15)
 		cu.SetDefault("manager.jobs.movieReconcile", time.Minute*10)
 		c, err := New(cu)
@@ -77,11 +75,11 @@ func TestNew(t *testing.T) {
 
 		wantConfig := Config{
 			TMDB: TMDB{
-				Scheme: "https",
+				URI:    "https://api.themoviedb.org",
 				APIKey: "fake-key",
 			},
 			Prowlarr: Prowlarr{
-				Scheme: "http",
+				URI: "http://localhost",
 			},
 			Manager: Manager{
 				Jobs: Jobs{

--- a/config/testing/config.yaml
+++ b/config/testing/config.yaml
@@ -1,10 +1,8 @@
 tmdb:
-  host: my-host
-  scheme: https
+  uri: https://my-host
   apiKey: my-api-key
 prowlarr:
-  host: my-prowlarr-host
-  scheme: https
+  uri: https://my-prowlarr-host
   apiKey: my-prowlarr-api-key
 manager:
   jobs:

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,7 +2,9 @@ package storage
 
 import (
 	"context"
+	"embed"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/go-jet/jet/v2/sqlite"
@@ -11,6 +13,9 @@ import (
 )
 
 var ErrNotFound = errors.New("not found in storage")
+
+//go:embed sqlite/schema/*.sql
+var schemaFiles embed.FS
 
 type Storage interface {
 	Init(ctx context.Context, schemas ...string) error
@@ -273,6 +278,27 @@ func ReadSchemaFiles(files ...string) ([]string, error) {
 
 		schemas = append(schemas, string(f))
 	}
+
+	return schemas, nil
+}
+
+// GetSchemas returns the embedded SQL schema files as string slices
+func GetSchemas() ([]string, error) {
+	var schemas []string
+
+	// Read schema.sql
+	schemaSQL, err := schemaFiles.ReadFile("sqlite/schema/schema.sql")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read schema.sql: %w", err)
+	}
+	schemas = append(schemas, string(schemaSQL))
+
+	// Read defaults.sql
+	defaultsSQL, err := schemaFiles.ReadFile("sqlite/schema/defaults.sql")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read defaults.sql: %w", err)
+	}
+	schemas = append(schemas, string(defaultsSQL))
 
 	return schemas, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -282,7 +282,7 @@ func ReadSchemaFiles(files ...string) ([]string, error) {
 	return schemas, nil
 }
 
-// GetSchemas returns the embedded SQL schema files as string slices
+// GetSchemas returns the SQL schema files as string slices
 func GetSchemas() ([]string, error) {
 	var schemas []string
 

--- a/server/server.go
+++ b/server/server.go
@@ -698,7 +698,7 @@ func (s Server) StaticFileHandler() http.Handler {
 			requestPath = "/index.html"
 		}
 
-		path := filepath.Join(s.config.StaticAssetsDir, requestPath)
+		path := filepath.Join(s.config.DistDir, requestPath)
 		f, err := os.Stat(path)
 		if err == nil && !f.IsDir() {
 			http.ServeFile(w, r, path)


### PR DESCRIPTION
A few small changes...

Added support to serve static files:
* `http://localhost:8080/api/v1/<endpoint>` will serve the api
* `http://localhost:8080/` will serve the index.html if nothing else is on the path
* `http://localhost:8080/path/to/abc.js` will serve the static file if it exists and is not a directory, otherwise 404s

The static file path can be configured under the server.distDir key or `SERVER_DISTDIR` env var, but defaults to the value below
```yaml
server:
  distDir: "./frontend/dist"
```

Config changes:
* Simplified Prowlarr and TMDB configs to use single URI fields instead of separate scheme/host
* Updated all command files and tests to use new URI format

Local config would now look like this for prowlarr
```yaml
prowlarr:
  uri: "https://prowlarr.int.kyledev.co"
  apiKey: "my-key"
```

Build Changes:
* Embedded SQL schemas into binary with `go:embed` so we can reference them at runtime and not worry about where they live
* Started the venture to containers by adding a simple Dockerfile