### PR TITLE
Bugfix/frontend api url

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,7 @@
  * API client for the Mediaz media management platform
  */
 
-const API_BASE_URL = 'http://localhost:8080/api/v1';
+const API_BASE_URL = '/api/v1';
 
 /**
  * Generic API response wrapper

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,10 @@
  * API client for the Mediaz media management platform
  */
 
-const API_BASE_URL = '/api/v1';
+const API_BASE_URL =
+  import.meta.env.VITE_API_HOST
+    ? `${import.meta.env.VITE_API_HOST}/api/v1`
+    : "/api/v1";
 
 /**
  * Generic API response wrapper

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,18 +3,23 @@ import react from "@vitejs/plugin-react-swc";
 import path from "node:path";
 import { componentTagger } from "lovable-tagger";
 
-export default defineConfig(({ mode }) => ({
-	base: mode === "production" ? "/static/" : "/",
-	server: {
-		host: "::",
-		port: 8080,
-	},
-	plugins: [react(), mode === "development" && componentTagger()].filter(
-		Boolean,
-	),
-	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+	const apiHost = mode === "production" ? "" : "http://localhost:8080";
+
+	return {
+		base: mode === "production" ? "/static/" : "/",
+		define: {
+			"import.meta.env.VITE_API_HOST": JSON.stringify(apiHost),
 		},
-	},
-}));
+		server: {
+			host: "::",
+			port: 8080,
+		},
+		plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
+		resolve: {
+			alias: {
+				"@": path.resolve(__dirname, "./src"),
+			},
+		},
+	};
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { componentTagger } from "lovable-tagger";
 
 export default defineConfig(({ mode }) => ({
+	base: mode === "production" ? "/static/" : "/",
 	server: {
 		host: "::",
 		port: 8080,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make API base URL configurable via environment variable in `api.ts` and update `vite.config.ts` to set this variable based on mode.
> 
>   - **API Base URL Configuration**:
>     - In `api.ts`, `API_BASE_URL` now uses `import.meta.env.VITE_API_HOST` if available, otherwise defaults to `"/api/v1"`.
>   - **Vite Configuration**:
>     - In `vite.config.ts`, sets `import.meta.env.VITE_API_HOST` to `"http://localhost:8080"` in development mode and an empty string in production mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kasuboski%2Fmediaz&utm_source=github&utm_medium=referral)<sup> for 92c3bbd5084752e0856f0323aa61507ebe804e75. You can [customize](https://app.ellipsis.dev/kasuboski/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->