### PR TITLE
Revert "add new schema field for relationship between series metadata…

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -821,8 +821,7 @@ func (m MediaManager) AddSeriesToLibrary(ctx context.Context, request AddSeriesR
 
 	log.Debug("created new missing series", zap.Any("series", series))
 
-	// Find season metadata that belongs to this series metadata
-	where := table.SeasonMetadata.SeriesMetadataID.EQ(sqlite.Int32(seriesMetadata.ID))
+	where := table.SeasonMetadata.SeriesID.EQ(sqlite.Int(seriesID))
 	seasonMetadata, err := m.storage.ListSeasonMetadata(ctx, where)
 	if err != nil {
 		return nil, err
@@ -840,13 +839,6 @@ func (m MediaManager) AddSeriesToLibrary(ctx context.Context, request AddSeriesR
 		seasonID, err := m.storage.CreateSeason(ctx, season, storage.SeasonStateMissing)
 		if err != nil {
 			log.Error("failed to create season", zap.Error(err))
-			return nil, err
-		}
-
-		// Update the season metadata to point to the actual series.id
-		err = m.storage.UpdateSeasonMetadataSeriesID(ctx, s.ID, int32(seriesID))
-		if err != nil {
-			log.Error("failed to update season metadata series_id", zap.Error(err))
 			return nil, err
 		}
 

--- a/pkg/manager/metadata.go
+++ b/pkg/manager/metadata.go
@@ -88,9 +88,7 @@ func (m MediaManager) loadSeriesMetadata(ctx context.Context, tmdbID int) (*mode
 
 	for _, s := range details.Seasons {
 		season := FromSeriesSeasons(s)
-		// Set SeriesMetadataID to link this season metadata to the series metadata
-		season.SeriesMetadataID = int32(seriesMetadataID)
-		// SeriesID will be set later during reconciliation when the actual series record exists
+		season.SeriesID = int32(seriesMetadataID)
 
 		existingSeason, err := m.storage.GetSeasonMetadata(ctx, table.SeasonMetadata.TmdbID.EQ(sqlite.Int(int64(season.TmdbID))))
 		if err != nil && !errors.Is(err, storage.ErrNotFound) {

--- a/pkg/manager/series_reconcile_test.go
+++ b/pkg/manager/series_reconcile_test.go
@@ -1280,11 +1280,10 @@ func TestMediaManager_ReconcileContinuingSeries(t *testing.T) {
 		require.NoError(t, err)
 
 		seasonMetadataID, err := store.CreateSeasonMetadata(ctx, model.SeasonMetadata{
-			SeriesID:         int32(seriesID),         // Reference the actual series ID
-			SeriesMetadataID: int32(seriesMetadataID), // Reference the series metadata ID
-			Title:            "Season 1",
-			Number:           1,
-			TmdbID:           1001, // Match the TMDB ID from our mock
+			SeriesID: int32(seriesMetadataID), // Should reference the series metadata ID, not storage series ID
+			Title:    "Season 1",
+			Number:   1,
+			TmdbID:   1001, // Match the TMDB ID from our mock
 		})
 		require.NoError(t, err)
 
@@ -1713,10 +1712,9 @@ func TestMediaManager_ReconcileDiscoveredEpisodes(t *testing.T) {
 
 		// Create season metadata
 		seasonMetadataID, err := store.CreateSeasonMetadata(ctx, model.SeasonMetadata{
-			SeriesID:         int32(seriesID),         // Reference the actual series ID
-			SeriesMetadataID: int32(seriesMetadataID), // Reference the series metadata ID
-			Title:            "Season 1",
-			Number:           1,
+			SeriesID: int32(seriesMetadataID),
+			Title:    "Season 1",
+			Number:   1,
 		})
 		require.NoError(t, err)
 

--- a/pkg/storage/mocks/mock_storage.go
+++ b/pkg/storage/mocks/mock_storage.go
@@ -1153,20 +1153,6 @@ func (mr *MockStorageMockRecorder) UpdateMovieState(ctx, id, state, metadata any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMovieState", reflect.TypeOf((*MockStorage)(nil).UpdateMovieState), ctx, id, state, metadata)
 }
 
-// UpdateSeasonMetadataSeriesID mocks base method.
-func (m *MockStorage) UpdateSeasonMetadataSeriesID(ctx context.Context, seasonMetadataID, seriesID int32) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSeasonMetadataSeriesID", ctx, seasonMetadataID, seriesID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateSeasonMetadataSeriesID indicates an expected call of UpdateSeasonMetadataSeriesID.
-func (mr *MockStorageMockRecorder) UpdateSeasonMetadataSeriesID(ctx, seasonMetadataID, seriesID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSeasonMetadataSeriesID", reflect.TypeOf((*MockStorage)(nil).UpdateSeasonMetadataSeriesID), ctx, seasonMetadataID, seriesID)
-}
-
 // UpdateSeasonState mocks base method.
 func (m *MockStorage) UpdateSeasonState(ctx context.Context, id int64, season storage.SeasonState, metadata *storage.TransitionStateMetadata) error {
 	m.ctrl.T.Helper()
@@ -2474,18 +2460,4 @@ func (mr *MockSeriesMetadataStorageMockRecorder) ListSeriesMetadata(ctx any, whe
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx}, where...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeriesMetadata", reflect.TypeOf((*MockSeriesMetadataStorage)(nil).ListSeriesMetadata), varargs...)
-}
-
-// UpdateSeasonMetadataSeriesID mocks base method.
-func (m *MockSeriesMetadataStorage) UpdateSeasonMetadataSeriesID(ctx context.Context, seasonMetadataID, seriesID int32) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateSeasonMetadataSeriesID", ctx, seasonMetadataID, seriesID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateSeasonMetadataSeriesID indicates an expected call of UpdateSeasonMetadataSeriesID.
-func (mr *MockSeriesMetadataStorageMockRecorder) UpdateSeasonMetadataSeriesID(ctx, seasonMetadataID, seriesID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSeasonMetadataSeriesID", reflect.TypeOf((*MockSeriesMetadataStorage)(nil).UpdateSeasonMetadataSeriesID), ctx, seasonMetadataID, seriesID)
 }

--- a/pkg/storage/sqlite/schema/gen/model/season_metadata.go
+++ b/pkg/storage/sqlite/schema/gen/model/season_metadata.go
@@ -12,12 +12,11 @@ import (
 )
 
 type SeasonMetadata struct {
-	ID               int32 `sql:"primary_key"`
-	SeriesID         int32
-	SeriesMetadataID int32
-	Number           int32
-	TmdbID           int32
-	Title            string
-	Overview         *string
-	AirDate          *time.Time
+	ID       int32 `sql:"primary_key"`
+	SeriesID int32
+	Number   int32
+	TmdbID   int32
+	Title    string
+	Overview *string
+	AirDate  *time.Time
 }

--- a/pkg/storage/sqlite/schema/gen/table/season_metadata.go
+++ b/pkg/storage/sqlite/schema/gen/table/season_metadata.go
@@ -17,14 +17,13 @@ type seasonMetadataTable struct {
 	sqlite.Table
 
 	// Columns
-	ID               sqlite.ColumnInteger
-	SeriesID         sqlite.ColumnInteger
-	SeriesMetadataID sqlite.ColumnInteger
-	Number           sqlite.ColumnInteger
-	TmdbID           sqlite.ColumnInteger
-	Title            sqlite.ColumnString
-	Overview         sqlite.ColumnString
-	AirDate          sqlite.ColumnTimestamp
+	ID       sqlite.ColumnInteger
+	SeriesID sqlite.ColumnInteger
+	Number   sqlite.ColumnInteger
+	TmdbID   sqlite.ColumnInteger
+	Title    sqlite.ColumnString
+	Overview sqlite.ColumnString
+	AirDate  sqlite.ColumnTimestamp
 
 	AllColumns     sqlite.ColumnList
 	MutableColumns sqlite.ColumnList
@@ -65,30 +64,28 @@ func newSeasonMetadataTable(schemaName, tableName, alias string) *SeasonMetadata
 
 func newSeasonMetadataTableImpl(schemaName, tableName, alias string) seasonMetadataTable {
 	var (
-		IDColumn               = sqlite.IntegerColumn("id")
-		SeriesIDColumn         = sqlite.IntegerColumn("series_id")
-		SeriesMetadataIDColumn = sqlite.IntegerColumn("series_metadata_id")
-		NumberColumn           = sqlite.IntegerColumn("number")
-		TmdbIDColumn           = sqlite.IntegerColumn("tmdb_id")
-		TitleColumn            = sqlite.StringColumn("title")
-		OverviewColumn         = sqlite.StringColumn("overview")
-		AirDateColumn          = sqlite.TimestampColumn("air_date")
-		allColumns             = sqlite.ColumnList{IDColumn, SeriesIDColumn, SeriesMetadataIDColumn, NumberColumn, TmdbIDColumn, TitleColumn, OverviewColumn, AirDateColumn}
-		mutableColumns         = sqlite.ColumnList{SeriesIDColumn, SeriesMetadataIDColumn, NumberColumn, TmdbIDColumn, TitleColumn, OverviewColumn, AirDateColumn}
+		IDColumn       = sqlite.IntegerColumn("id")
+		SeriesIDColumn = sqlite.IntegerColumn("series_id")
+		NumberColumn   = sqlite.IntegerColumn("number")
+		TmdbIDColumn   = sqlite.IntegerColumn("tmdb_id")
+		TitleColumn    = sqlite.StringColumn("title")
+		OverviewColumn = sqlite.StringColumn("overview")
+		AirDateColumn  = sqlite.TimestampColumn("air_date")
+		allColumns     = sqlite.ColumnList{IDColumn, SeriesIDColumn, NumberColumn, TmdbIDColumn, TitleColumn, OverviewColumn, AirDateColumn}
+		mutableColumns = sqlite.ColumnList{SeriesIDColumn, NumberColumn, TmdbIDColumn, TitleColumn, OverviewColumn, AirDateColumn}
 	)
 
 	return seasonMetadataTable{
 		Table: sqlite.NewTable(schemaName, tableName, alias, allColumns...),
 
 		//Columns
-		ID:               IDColumn,
-		SeriesID:         SeriesIDColumn,
-		SeriesMetadataID: SeriesMetadataIDColumn,
-		Number:           NumberColumn,
-		TmdbID:           TmdbIDColumn,
-		Title:            TitleColumn,
-		Overview:         OverviewColumn,
-		AirDate:          AirDateColumn,
+		ID:       IDColumn,
+		SeriesID: SeriesIDColumn,
+		Number:   NumberColumn,
+		TmdbID:   TmdbIDColumn,
+		Title:    TitleColumn,
+		Overview: OverviewColumn,
+		AirDate:  AirDateColumn,
 
 		AllColumns:     allColumns,
 		MutableColumns: mutableColumns,

--- a/pkg/storage/sqlite/schema/schema.sql
+++ b/pkg/storage/sqlite/schema/schema.sql
@@ -131,14 +131,12 @@ CREATE TABLE IF NOT EXISTS "season" (
 CREATE TABLE IF NOT EXISTS "season_metadata" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     "series_id" INTEGER NOT NULL,
-    "series_metadata_id" INTEGER NOT NULL,
     "number" INTEGER NOT NULL,
     "tmdb_id" INTEGER NOT NULL UNIQUE,
     "title" TEXT NOT NULL,
     "overview" TEXT,
     "air_date" DATETIME,
-    FOREIGN KEY ("series_id") REFERENCES "series" ("id"),
-    FOREIGN KEY ("series_metadata_id") REFERENCES "series_metadata" ("id")
+    FOREIGN KEY ("series_id") REFERENCES "series" ("id")
 );
 
 CREATE TABLE IF NOT EXISTS "episode" (

--- a/pkg/storage/sqlite/series.go
+++ b/pkg/storage/sqlite/series.go
@@ -811,13 +811,6 @@ func (s *SQLite) GetSeasonMetadata(ctx context.Context, where sqlite.BoolExpress
 	return &seasonMetadata, nil
 }
 
-// UpdateSeasonMetadataSeriesID updates the series_id field of season_metadata
-func (s *SQLite) UpdateSeasonMetadataSeriesID(ctx context.Context, seasonMetadataID int32, seriesID int32) error {
-	stmt := table.SeasonMetadata.UPDATE(table.SeasonMetadata.SeriesID).SET(seriesID).WHERE(table.SeasonMetadata.ID.EQ(sqlite.Int32(seasonMetadataID)))
-	_, err := stmt.Exec(s.db)
-	return err
-}
-
 // CreateEpisodeMetadata creates the given episodeMeta
 func (s *SQLite) CreateEpisodeMetadata(ctx context.Context, episodeMeta model.EpisodeMetadata) (int64, error) {
 	// don't insert a zeroed ID

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -269,7 +269,6 @@ type SeriesMetadataStorage interface {
 	DeleteSeasonMetadata(ctx context.Context, id int64) error
 	ListSeasonMetadata(ctx context.Context, where ...sqlite.BoolExpression) ([]*model.SeasonMetadata, error)
 	GetSeasonMetadata(ctx context.Context, where sqlite.BoolExpression) (*model.SeasonMetadata, error)
-	UpdateSeasonMetadataSeriesID(ctx context.Context, seasonMetadataID int32, seriesID int32) error
 
 	CreateEpisodeMetadata(ctx context.Context, episodeMeta model.EpisodeMetadata) (int64, error)
 	DeleteEpisodeMetadata(ctx context.Context, id int64) error


### PR DESCRIPTION
… and season metadata (#82)"

This reverts commit 815ee424be6c28d65e24ccb7e65d6e521428cb91.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Revert addition of `SeriesMetadataID` field in `SeasonMetadata`, updating related logic and mocks.
> 
>   - **Schema Changes**:
>     - Remove `SeriesMetadataID` from `SeasonMetadata` in `season_metadata.go`, `season_metadata.go`, and `schema.sql`.
>   - **Code Changes**:
>     - Update `AddSeriesToLibrary()` in `manager.go` to use `SeriesID` instead of `SeriesMetadataID`.
>     - Remove `UpdateSeasonMetadataSeriesID()` from `series.go` and `storage.go`.
>   - **Mock Changes**:
>     - Remove `UpdateSeasonMetadataSeriesID()` from `mock_storage.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kasuboski%2Fmediaz&utm_source=github&utm_medium=referral)<sup> for 2444355bb7428bbca71ecbba7cceb1695a355c4a. You can [customize](https://app.ellipsis.dev/kasuboski/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->