### PR TITLE
93 discovery reconcilliation should not require indexers

### DIFF
--- a/pkg/manager/movie_reconcile.go
+++ b/pkg/manager/movie_reconcile.go
@@ -95,14 +95,7 @@ func (m MediaManager) ReconcileMovies(ctx context.Context) error {
 		return err
 	}
 
-	indexers, err := m.ListIndexers(ctx)
-	if err != nil {
-		return err
-	}
-
-	log.Debugw("listed indexers", "count", len(indexers))
-
-	snapshot := newReconcileSnapshot(indexers, dcs)
+	snapshot := newReconcileSnapshot(make([]Indexer, 0), dcs)
 
 	err = m.ReconcileMissingMovies(ctx, snapshot)
 	if err != nil {
@@ -129,15 +122,23 @@ func (m MediaManager) ReconcileMovies(ctx context.Context) error {
 
 func (m MediaManager) ReconcileMissingMovies(ctx context.Context, snapshot *ReconcileSnapshot) error {
 	log := logger.FromCtx(ctx)
+	log.Debug("starting missing movies reconciliation")
 
 	if snapshot == nil {
 		return fmt.Errorf("snapshot is nil")
 	}
 
-	if len(snapshot.GetIndexers()) == 0 {
+	indexers, err := m.ListIndexers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list indexers: %w", err)
+	}
+
+	if len(indexers) == 0 {
 		log.Warn("Skipping missing movies reconciliation: no indexers available")
 		return nil
 	}
+
+	snapshot = newReconcileSnapshot(indexers, snapshot.GetDownloadClients())
 
 	movies, err := m.storage.ListMoviesByState(ctx, storage.MovieStateMissing)
 	if err != nil {
@@ -160,6 +161,8 @@ func (m MediaManager) ReconcileMissingMovies(ctx context.Context, snapshot *Reco
 
 func (m MediaManager) ReconcileDownloadingMovies(ctx context.Context, snapshot *ReconcileSnapshot) error {
 	log := logger.FromCtx(ctx)
+	log.Debug("starting downloading movies reconciliation")
+
 	movies, err := m.storage.ListMoviesByState(ctx, storage.MovieStateDownloading)
 	if err != nil {
 		return fmt.Errorf("couldn't list downloading movies: %w", err)
@@ -344,11 +347,12 @@ func (m MediaManager) reconcileMissingMovie(ctx context.Context, movie *storage.
 }
 
 func (m MediaManager) ReconcileUnreleasedMovies(ctx context.Context, snapshot *ReconcileSnapshot) error {
+	log := logger.FromCtx(ctx)
+	log.Debug("starting unreleased movies reconciliation")
+
 	if snapshot == nil {
 		return fmt.Errorf("snapshot is nil")
 	}
-
-	log := logger.FromCtx(ctx)
 
 	movies, err := m.storage.ListMoviesByState(ctx, storage.MovieStateUnreleased)
 	if err != nil {
@@ -411,6 +415,9 @@ func (m MediaManager) updateMovieState(ctx context.Context, movie *storage.Movie
 }
 
 func (m MediaManager) ReconcileDiscoveredMovies(ctx context.Context, snapshot *ReconcileSnapshot) error {
+	log := logger.FromCtx(ctx)
+	log.Debug("starting discovered movies reconciliation")
+
 	if snapshot == nil {
 		return fmt.Errorf("snapshot is nil")
 	}
@@ -419,8 +426,6 @@ func (m MediaManager) ReconcileDiscoveredMovies(ctx context.Context, snapshot *R
 	if err != nil {
 		return fmt.Errorf("couldn't list discovered movies: %w", err)
 	}
-
-	log := logger.FromCtx(ctx)
 
 	for _, movie := range movies {
 		if err := ctx.Err(); err != nil {

--- a/pkg/manager/series_reconcile.go
+++ b/pkg/manager/series_reconcile.go
@@ -26,14 +26,7 @@ func (m MediaManager) ReconcileSeries(ctx context.Context) error {
 		return err
 	}
 
-	indexers, err := m.ListIndexers(ctx)
-	if err != nil {
-		return err
-	}
-
-	log.Debug("listed indexers", zap.Int("count", len(indexers)))
-
-	snapshot := newReconcileSnapshot(indexers, dcs)
+	snapshot := newReconcileSnapshot(make([]Indexer, 0), dcs)
 
 	err = m.ReconcileMissingSeries(ctx, snapshot)
 	if err != nil {
@@ -70,16 +63,24 @@ func (m MediaManager) ReconcileSeries(ctx context.Context) error {
 
 func (m MediaManager) ReconcileMissingSeries(ctx context.Context, snapshot *ReconcileSnapshot) error {
 	log := logger.FromCtx(ctx)
+	log.Debug("starting missing series reconciliation")
 
 	if snapshot == nil {
 		log.Warn("snapshot is nil, skipping reconcile")
 		return nil
 	}
 
-	if len(snapshot.GetIndexers()) == 0 {
+	indexers, err := m.ListIndexers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list indexers: %w", err)
+	}
+
+	if len(indexers) == 0 {
 		log.Warn("Skipping missing series reconciliation: no indexers available")
 		return nil
 	}
+
+	snapshot = newReconcileSnapshot(indexers, snapshot.GetDownloadClients())
 
 	where := table.SeriesTransition.ToState.EQ(sqlite.String(string(storage.SeriesStateMissing))).
 		AND(table.SeriesTransition.MostRecent.EQ(sqlite.Bool(true))).
@@ -112,6 +113,7 @@ func (m MediaManager) ReconcileMissingSeries(ctx context.Context, snapshot *Reco
 
 func (m MediaManager) ReconcileContinuingSeries(ctx context.Context, snapshot *ReconcileSnapshot) error {
 	log := logger.FromCtx(ctx)
+	log.Debug("starting continuing series reconciliation")
 
 	if snapshot == nil {
 		log.Warn("snapshot is nil, skipping reconcile")
@@ -910,6 +912,7 @@ func (m MediaManager) evaluateAndUpdateSeriesState(ctx context.Context, seriesID
 // files on disk that need to be associated with the proper metadata before transitioning to "completed" state.
 func (m MediaManager) ReconcileDiscoveredEpisodes(ctx context.Context, snapshot *ReconcileSnapshot) error {
 	log := logger.FromCtx(ctx)
+	log.Debug("starting discovered episodes reconciliation")
 
 	where := table.EpisodeTransition.ToState.EQ(sqlite.String(string(storage.EpisodeStateDiscovered))).
 		AND(table.EpisodeTransition.MostRecent.EQ(sqlite.Bool(true))).
@@ -1237,6 +1240,7 @@ func (m MediaManager) getEpisodeFileByID(ctx context.Context, fileID int32) (*mo
 // ReconcileCompletedSeries evaluates and updates states for series that may have completed
 func (m MediaManager) ReconcileCompletedSeries(ctx context.Context) error {
 	log := logger.FromCtx(ctx)
+	log.Debug("starting completed series reconciliation")
 
 	where := table.SeriesTransition.ToState.IN(
 		sqlite.String(string(storage.SeriesStateDownloading)),
@@ -1269,6 +1273,7 @@ func (m MediaManager) ReconcileCompletedSeries(ctx context.Context) error {
 // ReconcileCompletedSeasons evaluates and updates states for seasons that may have completed
 func (m MediaManager) ReconcileCompletedSeasons(ctx context.Context) error {
 	log := logger.FromCtx(ctx)
+	log.Debug("starting completed seasons reconciliation")
 
 	where := table.SeasonTransition.ToState.IN(
 		sqlite.String(string(storage.SeasonStateDownloading)),


### PR DESCRIPTION
This moves the check for 0 indexers to only the missing movies/series reconcile loops will bail out. The other loops do not need access to the indexers
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor movie and series reconciliation to only require indexers for missing movies/series reconciliation, allowing other processes to proceed without indexers.
> 
>   - **Behavior**:
>     - `ReconcileMovies` and `ReconcileSeries` no longer require indexers for general reconciliation in `movie_reconcile.go` and `series_reconcile.go`.
>     - Indexer check moved to `ReconcileMissingMovies` and `ReconcileMissingSeries`.
>     - Logs a warning and skips missing movies/series reconciliation if no indexers are available.
>   - **Logging**:
>     - Added debug logs for starting reconciliation in `ReconcileMissingMovies`, `ReconcileDownloadingMovies`, `ReconcileUnreleasedMovies`, `ReconcileDiscoveredMovies`, `ReconcileMissingSeries`, `ReconcileContinuingSeries`, `ReconcileDiscoveredEpisodes`, `ReconcileCompletedSeries`, and `ReconcileCompletedSeasons`.
>   - **Tests**:
>     - Updated `TestMediaManager_ReconcileMissingSeries` in `series_reconcile_test.go` to reflect changes in indexer requirement.
>     - Added mock expectations for indexer listing in test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=kasuboski%2Fmediaz&utm_source=github&utm_medium=referral)<sup> for 287f24c8f1258712c15b67540841bfe5f6c75ec3. You can [customize](https://app.ellipsis.dev/kasuboski/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->