### PR TITLE
Fix: O(n×m) movie library indexing loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ mediaz
 
 config.yaml
 testlib
+
+STATUS.md

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -736,32 +736,32 @@ func (m MediaManager) IndexMovieLibrary(ctx context.Context) error {
 		return fmt.Errorf("failed to list movie files: %w", err)
 	}
 
-	for _, discoveredFile := range discoveredFiles {
-		// need to check if the file is already tracked, and if not, add it
-		isTracked := false
-		for _, mf := range movieFiles {
-			if mf == nil {
-				continue
-			}
-
-			if strings.EqualFold(*mf.RelativePath, discoveredFile.RelativePath) {
-				log.Debug("discovered file relative path matches monitored movie file relative path",
-					zap.String("discovered file relative path", discoveredFile.RelativePath),
-					zap.String("monitored file relative path", *mf.RelativePath))
-				isTracked = true
-				break
-			}
-
-			if strings.EqualFold(*mf.OriginalFilePath, discoveredFile.AbsolutePath) {
-				log.Debug("discovered file absolute path matches monitored movie file original path",
-					zap.String("discovered file absolute path", discoveredFile.AbsolutePath),
-					zap.String("monitored file original path", *mf.OriginalFilePath))
-				isTracked = true
-				break
-			}
+	// Build a set of tracked paths for O(1) lookup instead of O(n*m) nested loop
+	tracked := make(map[string]struct{}, len(movieFiles)*2)
+	for _, mf := range movieFiles {
+		if mf == nil {
+			continue
 		}
+		if mf.RelativePath != nil {
+			tracked[strings.ToLower(*mf.RelativePath)] = struct{}{}
+		}
+		if mf.OriginalFilePath != nil {
+			tracked[strings.ToLower(*mf.OriginalFilePath)] = struct{}{}
+		}
+	}
 
-		if isTracked {
+	for _, discoveredFile := range discoveredFiles {
+		_, trackedByRelPath := tracked[strings.ToLower(discoveredFile.RelativePath)]
+		_, trackedByAbsPath := tracked[strings.ToLower(discoveredFile.AbsolutePath)]
+
+		if trackedByRelPath {
+			log.Debug("discovered file relative path matches monitored movie file relative path",
+				zap.String("discovered file relative path", discoveredFile.RelativePath))
+			continue
+		}
+		if trackedByAbsPath {
+			log.Debug("discovered file absolute path matches monitored movie file original path",
+				zap.String("discovered file absolute path", discoveredFile.AbsolutePath))
 			continue
 		}
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -496,6 +496,38 @@ func TestIndexMovieLibrary(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, movies, 1)
 	})
+
+	t.Run("skips files tracked with different casing", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
+
+		store := newStore(t, ctx)
+		mockLibrary := mockLibrary.NewMockLibrary(ctrl)
+
+		_, err := store.CreateMovieFile(ctx, model.MovieFile{
+			Size:             1024,
+			RelativePath:     ptr("Movie 1/MOVIE1.MP4"),
+			OriginalFilePath: ptr("/movies/Movie 1/MOVIE1.MP4"),
+		})
+		require.NoError(t, err)
+
+		discoveredFiles := []library.MovieFile{
+			{RelativePath: "movie 1/movie1.mp4", AbsolutePath: "/movies/movie 1/movie1.mp4"},
+		}
+
+		mockLibrary.EXPECT().FindMovies(ctx).Times(1).Return(discoveredFiles, nil)
+
+		m := New(nil, nil, mockLibrary, store, nil, config.Manager{}, config.Config{})
+		require.NotNil(t, m)
+
+		err = m.IndexMovieLibrary(ctx)
+		assert.NoError(t, err)
+
+		// Should not create a new movie file since it's already tracked (case-insensitive)
+		movieFiles, err := store.ListMovieFiles(ctx)
+		require.NoError(t, err)
+		assert.Len(t, movieFiles, 1)
+	})
 }
 
 func TestMovieRejectRelease(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #131 (parent: #126)

Replaces the O(n×m) nested loop in `IndexMovieLibrary` with an O(n+m) map-based lookup. For a library with 1000 movies and 1000 tracked files, this eliminates ~1,000,000 string comparisons in favor of ~2000 map operations.

## Changes

- **`pkg/manager/manager.go`**: Build a `map[string]struct{}` of lowered tracked paths (both `RelativePath` and `OriginalFilePath`) upfront, then do O(1) map lookups per discovered file instead of iterating all tracked files for each discovered file.
- **`pkg/manager/manager_test.go`**: Added new test case `"skips files tracked with different casing"` to verify case-insensitive matching is preserved after the refactor.

## Testing

All existing tests pass, plus a new test was added:

```
=== RUN   TestIndexMovieLibrary/skips_files_tracked_with_different_casing
--- PASS
```

Full test suite:
```bash
go test ./...
# All packages pass
```

The new test creates a tracked movie file with uppercase paths (`MOVIE1.MP4`), then discovers a file with lowercase paths (`movie1.mp4`). It verifies the file is recognized as already tracked (no duplicate created), confirming `strings.ToLower` in the map matches the previous `strings.EqualFold` behavior.

## Behavior Preserved

- Case-insensitive path comparison (was `strings.EqualFold`, now `strings.ToLower` on map key)
- Debug logging when a discovered file matches a tracked file
- All existing test cases continue to pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where library indexing could create duplicate file entries when tracked file paths differed only in character casing.

* **Performance**
  * Optimized duplicate file detection during library indexing for improved performance when discovering media files.

* **Chores**
  * Added project status documentation to track performance optimization progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->