### PR TITLE
Fix issues #127, #128, #130, #132

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -404,6 +404,56 @@ func (m MediaManager) getSeasonsWithEpisodes(ctx context.Context, seriesID int32
 	return results, nil
 }
 
+// buildEpisodeResult constructs an EpisodeResult from a storage episode and optional metadata.
+// resolveEpisodeMetadata looks up episode metadata by ID, returning nil on failure.
+func (m MediaManager) resolveEpisodeMetadata(ctx context.Context, metadataID *int32, log *zap.SugaredLogger) *model.EpisodeMetadata {
+	if metadataID == nil {
+		return nil
+	}
+	meta, err := m.storage.GetEpisodeMetadata(ctx,
+		table.EpisodeMetadata.ID.EQ(sqlite.Int32(*metadataID)))
+	if err != nil {
+		log.Error("failed to get episode metadata", zap.Error(err), zap.Int32("episodeMetadataID", *metadataID))
+		return nil
+	}
+	return meta
+}
+
+func buildEpisodeResult(episode *storage.Episode, episodeMeta *model.EpisodeMetadata, seriesID int32, seasonNumber int32) EpisodeResult {
+	result := EpisodeResult{
+		SeriesID:     seriesID,
+		SeasonNumber: seasonNumber,
+		Monitored:    episode.Monitored == 1,
+		Downloaded:   episode.State == storage.EpisodeStateDownloaded || episode.State == storage.EpisodeStateCompleted,
+	}
+
+	if episodeMeta != nil {
+		result.TMDBID = episodeMeta.TmdbID
+		result.Number = episodeMeta.Number
+		result.Title = episodeMeta.Title
+
+		if episodeMeta.Overview != nil {
+			result.Overview = episodeMeta.Overview
+		}
+		if episodeMeta.AirDate != nil {
+			airDateStr := episodeMeta.AirDate.Format("2006-01-02")
+			result.AirDate = &airDateStr
+		}
+		if episodeMeta.Runtime != nil {
+			result.Runtime = episodeMeta.Runtime
+		}
+		if episodeMeta.StillPath != nil {
+			result.StillPath = episodeMeta.StillPath
+		}
+	} else {
+		result.TMDBID = 0
+		result.Number = episode.EpisodeNumber
+		result.Title = fmt.Sprintf("Episode %d", episode.EpisodeNumber)
+	}
+
+	return result
+}
+
 // getEpisodesForSeason retrieves episodes for a specific season
 func (m MediaManager) getEpisodesForSeason(ctx context.Context, seasonID int32, seriesID int32, seasonNumber int32) ([]EpisodeResult, error) {
 	log := logger.FromCtx(ctx)
@@ -416,60 +466,10 @@ func (m MediaManager) getEpisodesForSeason(ctx context.Context, seasonID int32, 
 		return nil, err
 	}
 
-	// Transform to response format with metadata lookup
-	results := make([]EpisodeResult, 0)
+	results := make([]EpisodeResult, 0, len(episodes))
 	for _, episode := range episodes {
-		var episodeMeta *model.EpisodeMetadata
-
-		// Try to get episode metadata if available
-		if episode.EpisodeMetadataID != nil {
-			meta, err := m.storage.GetEpisodeMetadata(ctx,
-				table.EpisodeMetadata.ID.EQ(sqlite.Int32(*episode.EpisodeMetadataID)))
-			if err != nil {
-				log.Error("failed to get episode metadata", zap.Error(err), zap.Int32("episodeMetadataID", *episode.EpisodeMetadataID))
-				// Continue without metadata
-			} else {
-				episodeMeta = meta
-			}
-		}
-
-		// Build result with available data
-		result := EpisodeResult{
-			SeriesID:     seriesID,
-			SeasonNumber: seasonNumber,
-			Monitored:    episode.Monitored == 1,
-			Downloaded:   episode.State == storage.EpisodeStateDownloaded || episode.State == storage.EpisodeStateCompleted,
-		}
-
-		// Fill in metadata if available
-		if episodeMeta != nil {
-			result.TMDBID = episodeMeta.TmdbID
-			result.Number = episodeMeta.Number
-			result.Title = episodeMeta.Title
-
-			// Add optional fields
-			if episodeMeta.Overview != nil {
-				result.Overview = episodeMeta.Overview
-			}
-			if episodeMeta.AirDate != nil {
-				airDateStr := episodeMeta.AirDate.Format("2006-01-02")
-				result.AirDate = &airDateStr
-			}
-			if episodeMeta.Runtime != nil {
-				result.Runtime = episodeMeta.Runtime
-			}
-			if episodeMeta.StillPath != nil {
-				result.StillPath = episodeMeta.StillPath
-			}
-
-		} else {
-			// Fallback values for episodes without metadata
-			result.TMDBID = 0
-			result.Number = episode.EpisodeNumber
-			result.Title = fmt.Sprintf("Episode %d", episode.EpisodeNumber)
-		}
-
-		results = append(results, result)
+		episodeMeta := m.resolveEpisodeMetadata(ctx, episode.EpisodeMetadataID, log)
+		results = append(results, buildEpisodeResult(episode, episodeMeta, seriesID, seasonNumber))
 	}
 
 	return results, nil
@@ -1391,66 +1391,16 @@ func (m MediaManager) ListEpisodesForSeason(ctx context.Context, tmdbID int, sea
 		return nil, err
 	}
 
-	// Transform to response format with metadata lookup
-	results := make([]EpisodeResult, 0)
+	// Determine season number for response
+	seasonNum := int32(seasonNumber)
+	if seasonMeta != nil {
+		seasonNum = seasonMeta.Number
+	}
+
+	results := make([]EpisodeResult, 0, len(episodes))
 	for _, episode := range episodes {
-		var episodeMeta *model.EpisodeMetadata
-
-		// Try to get episode metadata if available
-		if episode.EpisodeMetadataID != nil {
-			meta, err := m.storage.GetEpisodeMetadata(ctx,
-				table.EpisodeMetadata.ID.EQ(sqlite.Int32(*episode.EpisodeMetadataID)))
-			if err != nil {
-				log.Error("failed to get episode metadata", zap.Error(err), zap.Int32("episodeMetadataID", *episode.EpisodeMetadataID))
-				// Continue without metadata
-			} else {
-				episodeMeta = meta
-			}
-		}
-
-		// Determine season number for response
-		seasonNum := int32(seasonNumber)
-		if seasonMeta != nil {
-			seasonNum = seasonMeta.Number
-		}
-
-		// Build result with available data
-		result := EpisodeResult{
-			SeriesID:     series.ID,
-			SeasonNumber: seasonNum,
-			Monitored:    episode.Monitored == 1,
-			Downloaded:   episode.State == storage.EpisodeStateDownloaded || episode.State == storage.EpisodeStateCompleted,
-		}
-
-		// Fill in metadata if available
-		if episodeMeta != nil {
-			result.TMDBID = episodeMeta.TmdbID
-			result.Number = episodeMeta.Number
-			result.Title = episodeMeta.Title
-
-			// Add optional fields
-			if episodeMeta.Overview != nil {
-				result.Overview = episodeMeta.Overview
-			}
-			if episodeMeta.AirDate != nil {
-				airDateStr := episodeMeta.AirDate.Format("2006-01-02")
-				result.AirDate = &airDateStr
-			}
-			if episodeMeta.Runtime != nil {
-				result.Runtime = episodeMeta.Runtime
-			}
-			if episodeMeta.StillPath != nil {
-				result.StillPath = episodeMeta.StillPath
-			}
-
-		} else {
-			// Fallback values for episodes without metadata
-			result.TMDBID = 0
-			result.Number = episode.EpisodeNumber
-			result.Title = fmt.Sprintf("Episode %d", episode.EpisodeNumber)
-		}
-
-		results = append(results, result)
+		episodeMeta := m.resolveEpisodeMetadata(ctx, episode.EpisodeMetadataID, log)
+		results = append(results, buildEpisodeResult(episode, episodeMeta, series.ID, seasonNum))
 	}
 
 	return results, nil

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -404,7 +404,6 @@ func (m MediaManager) getSeasonsWithEpisodes(ctx context.Context, seriesID int32
 	return results, nil
 }
 
-// buildEpisodeResult constructs an EpisodeResult from a storage episode and optional metadata.
 // resolveEpisodeMetadata looks up episode metadata by ID, returning nil on failure.
 func (m MediaManager) resolveEpisodeMetadata(ctx context.Context, metadataID *int32, log *zap.SugaredLogger) *model.EpisodeMetadata {
 	if metadataID == nil {
@@ -419,6 +418,7 @@ func (m MediaManager) resolveEpisodeMetadata(ctx context.Context, metadataID *in
 	return meta
 }
 
+// buildEpisodeResult constructs an EpisodeResult from a storage episode and optional metadata.
 func buildEpisodeResult(episode *storage.Episode, episodeMeta *model.EpisodeMetadata, seriesID int32, seasonNumber int32) EpisodeResult {
 	result := EpisodeResult{
 		SeriesID:     seriesID,

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -404,18 +404,31 @@ func (m MediaManager) getSeasonsWithEpisodes(ctx context.Context, seriesID int32
 	return results, nil
 }
 
-// resolveEpisodeMetadata looks up episode metadata by ID, returning nil on failure.
-func (m MediaManager) resolveEpisodeMetadata(ctx context.Context, metadataID *int32, log *zap.SugaredLogger) *model.EpisodeMetadata {
-	if metadataID == nil {
+// preloadEpisodeMetadata fetches all episode metadata for the given IDs in a single query,
+// returning a map keyed by metadata ID.
+func (m MediaManager) preloadEpisodeMetadata(ctx context.Context, episodes []*storage.Episode) map[int32]*model.EpisodeMetadata {
+	ids := make([]sqlite.Expression, 0, len(episodes))
+	for _, ep := range episodes {
+		if ep.EpisodeMetadataID != nil {
+			ids = append(ids, sqlite.Int32(*ep.EpisodeMetadataID))
+		}
+	}
+	if len(ids) == 0 {
 		return nil
 	}
-	meta, err := m.storage.GetEpisodeMetadata(ctx,
-		table.EpisodeMetadata.ID.EQ(sqlite.Int32(*metadataID)))
+
+	metas, err := m.storage.ListEpisodeMetadata(ctx, table.EpisodeMetadata.ID.IN(ids...))
 	if err != nil {
-		log.Error("failed to get episode metadata", zap.Error(err), zap.Int32("episodeMetadataID", *metadataID))
+		log := logger.FromCtx(ctx)
+		log.Error("failed to batch fetch episode metadata", zap.Error(err))
 		return nil
 	}
-	return meta
+
+	result := make(map[int32]*model.EpisodeMetadata, len(metas))
+	for _, meta := range metas {
+		result[meta.ID] = meta
+	}
+	return result
 }
 
 // buildEpisodeResult constructs an EpisodeResult from a storage episode and optional metadata.
@@ -467,8 +480,12 @@ func (m MediaManager) getEpisodesForSeason(ctx context.Context, seasonID int32, 
 	}
 
 	results := make([]EpisodeResult, 0, len(episodes))
+	metaMap := m.preloadEpisodeMetadata(ctx, episodes)
 	for _, episode := range episodes {
-		episodeMeta := m.resolveEpisodeMetadata(ctx, episode.EpisodeMetadataID, log)
+		var episodeMeta *model.EpisodeMetadata
+		if episode.EpisodeMetadataID != nil {
+			episodeMeta = metaMap[*episode.EpisodeMetadataID]
+		}
 		results = append(results, buildEpisodeResult(episode, episodeMeta, seriesID, seasonNumber))
 	}
 
@@ -1398,8 +1415,12 @@ func (m MediaManager) ListEpisodesForSeason(ctx context.Context, tmdbID int, sea
 	}
 
 	results := make([]EpisodeResult, 0, len(episodes))
+	metaMap := m.preloadEpisodeMetadata(ctx, episodes)
 	for _, episode := range episodes {
-		episodeMeta := m.resolveEpisodeMetadata(ctx, episode.EpisodeMetadataID, log)
+		var episodeMeta *model.EpisodeMetadata
+		if episode.EpisodeMetadataID != nil {
+			episodeMeta = metaMap[*episode.EpisodeMetadataID]
+		}
 		results = append(results, buildEpisodeResult(episode, episodeMeta, series.ID, seasonNum))
 	}
 

--- a/pkg/manager/metadata.go
+++ b/pkg/manager/metadata.go
@@ -164,8 +164,20 @@ func (m MediaManager) loadSeriesMetadata(ctx context.Context, tmdbID int) (*mode
 
 	seriesMetadataID, err := m.storage.CreateSeriesMetadata(ctx, series)
 	if err != nil {
-		log.Error("failed to create series metadata", zap.Error(err))
-		return nil, err
+		// If metadata already exists, update it and use the existing ID
+		existing, getErr := m.storage.GetSeriesMetadata(ctx, table.SeriesMetadata.TmdbID.EQ(sqlite.Int64(int64(series.TmdbID))))
+		if getErr != nil {
+			log.Error("failed to create or get series metadata", zap.Error(err), zap.Error(getErr))
+			return nil, err
+		}
+
+		series.ID = existing.ID
+		series.TmdbID = existing.TmdbID
+		if updateErr := m.storage.UpdateSeriesMetadata(ctx, series); updateErr != nil {
+			log.Error("failed to update existing series metadata", zap.Error(updateErr))
+			return nil, updateErr
+		}
+		seriesMetadataID = int64(existing.ID)
 	}
 
 	for _, s := range details.Seasons {
@@ -419,7 +431,6 @@ func (m MediaManager) fetchWatchProviders(ctx context.Context, tmdbID int) (*str
 
 // parseExternalIDs parses TMDB external IDs response
 func parseExternalIDs(resp *http.Response) (*ExternalIDsData, error) {
-	defer resp.Body.Close()
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
@@ -434,7 +445,6 @@ func parseExternalIDs(resp *http.Response) (*ExternalIDsData, error) {
 
 // parseWatchProviders parses TMDB watch providers response
 func parseWatchProviders(resp *http.Response) (*WatchProvidersData, error) {
-	defer resp.Body.Close()
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err

--- a/pkg/manager/metadata.go
+++ b/pkg/manager/metadata.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kasuboski/mediaz/pkg/storage/sqlite/schema/gen/model"
 	"github.com/kasuboski/mediaz/pkg/storage/sqlite/schema/gen/table"
 	"github.com/kasuboski/mediaz/pkg/tmdb"
+	"github.com/mattn/go-sqlite3"
 	"go.uber.org/zap"
 )
 
@@ -164,10 +165,16 @@ func (m MediaManager) loadSeriesMetadata(ctx context.Context, tmdbID int) (*mode
 
 	seriesMetadataID, err := m.storage.CreateSeriesMetadata(ctx, series)
 	if err != nil {
-		// If metadata already exists, update it and use the existing ID
+		var sqliteErr sqlite3.Error
+		if !errors.As(err, &sqliteErr) || sqliteErr.Code != sqlite3.ErrConstraint || sqliteErr.ExtendedCode != sqlite3.ErrConstraintUnique {
+			log.Error("failed to create series metadata", zap.Error(err))
+			return nil, err
+		}
+
+		// Unique constraint violation — metadata already exists, update it
 		existing, getErr := m.storage.GetSeriesMetadata(ctx, table.SeriesMetadata.TmdbID.EQ(sqlite.Int64(int64(series.TmdbID))))
 		if getErr != nil {
-			log.Error("failed to create or get series metadata", zap.NamedError("createErr", err), zap.NamedError("getErr", getErr))
+			log.Error("failed to get existing series metadata", zap.NamedError("createErr", err), zap.NamedError("getErr", getErr))
 			return nil, err
 		}
 

--- a/pkg/manager/metadata.go
+++ b/pkg/manager/metadata.go
@@ -175,7 +175,7 @@ func (m MediaManager) loadSeriesMetadata(ctx context.Context, tmdbID int) (*mode
 		existing, getErr := m.storage.GetSeriesMetadata(ctx, table.SeriesMetadata.TmdbID.EQ(sqlite.Int64(int64(series.TmdbID))))
 		if getErr != nil {
 			log.Error("failed to get existing series metadata", zap.NamedError("createErr", err), zap.NamedError("getErr", getErr))
-			return nil, err
+			return nil, getErr
 		}
 
 		series.ID = existing.ID

--- a/pkg/manager/metadata.go
+++ b/pkg/manager/metadata.go
@@ -167,7 +167,7 @@ func (m MediaManager) loadSeriesMetadata(ctx context.Context, tmdbID int) (*mode
 		// If metadata already exists, update it and use the existing ID
 		existing, getErr := m.storage.GetSeriesMetadata(ctx, table.SeriesMetadata.TmdbID.EQ(sqlite.Int64(int64(series.TmdbID))))
 		if getErr != nil {
-			log.Error("failed to create or get series metadata", zap.Error(err), zap.Error(getErr))
+			log.Error("failed to create or get series metadata", zap.NamedError("createErr", err), zap.NamedError("getErr", getErr))
 			return nil, err
 		}
 

--- a/pkg/manager/metadata_test.go
+++ b/pkg/manager/metadata_test.go
@@ -606,9 +606,7 @@ func TestMediaManager_loadSeriesMetadata_Upsert(t *testing.T) {
 
 		_, err := m.loadSeriesMetadata(ctx, 1234)
 		require.Error(t, err)
-		// Should return the original create error (not the get error)
-		var sqliteErr sqlite3.Error
-		assert.True(t, errors.As(err, &sqliteErr), "error should wrap the original sqlite3 error")
+		assert.Equal(t, "get failed", err.Error(), "should return the get error")
 	})
 }
 

--- a/pkg/manager/metadata_test.go
+++ b/pkg/manager/metadata_test.go
@@ -13,6 +13,7 @@ import (
 	storeMocks "github.com/kasuboski/mediaz/pkg/storage/mocks"
 	"github.com/kasuboski/mediaz/pkg/storage/sqlite/schema/gen/model"
 	"github.com/kasuboski/mediaz/pkg/tmdb"
+	"github.com/mattn/go-sqlite3"
 	tmdbMocks "github.com/kasuboski/mediaz/pkg/tmdb/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -493,6 +494,121 @@ func TestMediaManager_fetchWatchProviders(t *testing.T) {
 		result, err := m.fetchWatchProviders(ctx, 1234)
 		require.NoError(t, err)
 		assert.Nil(t, result)
+	})
+}
+
+func TestMediaManager_loadSeriesMetadata_Upsert(t *testing.T) {
+	t.Run("non-constraint create error returns immediately", func(t *testing.T) {
+		ctx := context.Background()
+		ctrl := gomock.NewController(t)
+
+		store := storeMocks.NewMockStorage(ctrl)
+		store.EXPECT().CreateSeriesMetadata(ctx, gomock.Any()).Return(int64(0), errors.New("some db failure"))
+
+		tmdbMock := tmdbMocks.NewMockITmdb(ctrl)
+		tmdbMock.EXPECT().GetSeriesDetails(ctx, 1234).Return(&tmdb.SeriesDetails{
+			ID:           1234,
+			Name:         "Test Series",
+			FirstAirDate: "2023-01-01",
+		}, nil)
+		tmdbMock.EXPECT().TvSeriesExternalIds(gomock.Any(), int32(1234)).Return(&http.Response{StatusCode: 404, Body: io.NopCloser(bytes.NewBufferString(``))}, nil)
+		tmdbMock.EXPECT().TvSeriesWatchProviders(gomock.Any(), int32(1234)).Return(&http.Response{StatusCode: 404, Body: io.NopCloser(bytes.NewBufferString(``))}, nil)
+
+		m := MediaManager{
+			tmdb:    tmdbMock,
+			storage: store,
+			configs: config.Manager{},
+		}
+
+		_, err := m.loadSeriesMetadata(ctx, 1234)
+		require.Error(t, err)
+		assert.Equal(t, "some db failure", err.Error())
+	})
+
+	t.Run("upsert on existing metadata", func(t *testing.T) {
+		ctx := context.Background()
+		store := newStore(t, ctx)
+
+		tmdbMock := tmdbMocks.NewMockITmdb(gomock.NewController(t))
+
+		tmdbMock.EXPECT().GetSeriesDetails(ctx, 1234).Return(&tmdb.SeriesDetails{
+			ID:              1234,
+			Name:            "Test Series",
+			FirstAirDate:    "2023-01-01",
+			NumberOfSeasons: 1,
+			Seasons: []tmdb.Season{
+				{
+					ID:           100,
+					Name:         "Season 1",
+					AirDate:      "2023-01-01",
+					SeasonNumber: 1,
+					Episodes: []tmdb.Episode{
+						{ID: 1001, Name: "Ep 1", AirDate: "2023-01-01", EpisodeNumber: 1, Runtime: 45},
+					},
+				},
+			},
+		}, nil).AnyTimes()
+
+		mockResp := func(body string) *http.Response {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewBufferString(body))}
+		}
+		tmdbMock.EXPECT().TvSeriesExternalIds(gomock.Any(), int32(1234)).Return(mockResp(`{"imdb_id":null}`), nil).AnyTimes()
+		tmdbMock.EXPECT().TvSeriesWatchProviders(gomock.Any(), int32(1234)).Return(mockResp(`{"results":{}}`), nil).AnyTimes()
+
+		m := MediaManager{
+			tmdb:    tmdbMock,
+			storage: store,
+			configs: config.Manager{},
+		}
+
+		// First call: creates metadata successfully
+		result1, err := m.loadSeriesMetadata(ctx, 1234)
+		require.NoError(t, err)
+		require.NotNil(t, result1)
+		assert.Equal(t, "Test Series", result1.Title)
+		assert.Equal(t, int32(1234), result1.TmdbID)
+
+		// Second call: hits unique constraint, falls back to update (upsert)
+		result2, err := m.loadSeriesMetadata(ctx, 1234)
+		require.NoError(t, err)
+		require.NotNil(t, result2)
+		assert.Equal(t, result1.ID, result2.ID, "should return same metadata record")
+		assert.Equal(t, int32(1234), result2.TmdbID)
+	})
+
+	t.Run("upsert when get fails after constraint violation", func(t *testing.T) {
+		ctx := context.Background()
+		ctrl := gomock.NewController(t)
+
+		store := storeMocks.NewMockStorage(ctrl)
+		// Simulate a unique constraint violation from SQLite
+		store.EXPECT().CreateSeriesMetadata(ctx, gomock.Any()).Return(int64(0), sqlite3.Error{
+			Code:         sqlite3.ErrConstraint,
+			ExtendedCode: sqlite3.ErrConstraintUnique,
+		})
+		// Then GetSeriesMetadata also fails
+		store.EXPECT().GetSeriesMetadata(ctx, gomock.Any()).Return(nil, errors.New("get failed"))
+
+		tmdbMock := tmdbMocks.NewMockITmdb(ctrl)
+		tmdbMock.EXPECT().GetSeriesDetails(ctx, 1234).Return(&tmdb.SeriesDetails{
+			ID:           1234,
+			Name:         "Test Series",
+			FirstAirDate: "2023-01-01",
+		}, nil)
+		tmdbMock.EXPECT().TvSeriesExternalIds(gomock.Any(), int32(1234)).Return(&http.Response{StatusCode: 404, Body: io.NopCloser(bytes.NewBufferString(``))}, nil)
+		tmdbMock.EXPECT().TvSeriesWatchProviders(gomock.Any(), int32(1234)).Return(&http.Response{StatusCode: 404, Body: io.NopCloser(bytes.NewBufferString(``))}, nil)
+
+		m := MediaManager{
+			tmdb:    tmdbMock,
+			storage: store,
+			configs: config.Manager{},
+		}
+
+		_, err := m.loadSeriesMetadata(ctx, 1234)
+		require.Error(t, err)
+		// Should return the original create error (not the get error)
+		var sqliteErr sqlite3.Error
+		assert.True(t, errors.As(err, &sqliteErr), "error should wrap the original sqlite3 error")
 	})
 }
 

--- a/pkg/manager/series_reconcile.go
+++ b/pkg/manager/series_reconcile.go
@@ -1199,6 +1199,10 @@ func (m MediaManager) linkSeriesMetadata(ctx context.Context, series *storage.Se
 }
 
 func findMatchingSeriesResult(results []*SearchMediaResult, year *int32) *SearchMediaResult {
+	if len(results) == 0 {
+		return nil
+	}
+
 	if year == nil {
 		return results[0]
 	}

--- a/pkg/manager/tv_detail_test.go
+++ b/pkg/manager/tv_detail_test.go
@@ -102,7 +102,7 @@ func TestGetTVDetailByTMDBID_WithSeasonsAndEpisodes(t *testing.T) {
 		store.EXPECT().ListSeasons(ctx, gomock.Any()).Return([]*storage.Season{season}, nil)
 		store.EXPECT().GetSeasonMetadata(ctx, gomock.Any()).Return(seasonMetadata, nil)
 		store.EXPECT().ListEpisodes(ctx, gomock.Any()).Return([]*storage.Episode{episode}, nil)
-		store.EXPECT().GetEpisodeMetadata(ctx, gomock.Any()).Return(episodeMetadata, nil)
+		store.EXPECT().ListEpisodeMetadata(ctx, gomock.Any()).Return([]*model.EpisodeMetadata{episodeMetadata}, nil)
 
 		result, err := m.GetTVDetailByTMDBID(ctx, tmdbID)
 		require.NoError(t, err)

--- a/server/series_handlers_test.go
+++ b/server/series_handlers_test.go
@@ -119,7 +119,7 @@ func TestServer_GetTVDetailByTMDBID(t *testing.T) {
 			TmdbID: 54321,
 			Title:  "Episode 1",
 		}
-		store.EXPECT().GetEpisodeMetadata(gomock.Any(), gomock.Any()).Return(episodeMetadata, nil)
+		store.EXPECT().ListEpisodeMetadata(gomock.Any(), gomock.Any()).Return([]*model.EpisodeMetadata{episodeMetadata}, nil)
 
 		// Create manager with mocked dependencies
 		mgr := manager.New(tmdbMock, nil, nil, store, nil, config.Manager{}, config.Config{})


### PR DESCRIPTION
## Summary

Fixes four bugs and one refactor from the GitHub issue tracker.

### #127 — Double Body.Close() in metadata fetch/parse
Removed `defer resp.Body.Close()` from `parseExternalIDs` and `parseWatchProviders`. The caller (`fetchExternalIDs`/`fetchWatchProviders`) already defers the close on the same `*http.Response`.

### #128 — findMatchingSeriesResult panics on empty results
Added `if len(results) == 0 { return nil }` check before accessing `results[0]`, matching the existing `findMatchingMovieResult` behavior.

### #130 — RefreshSeriesMetadataFromTMDB fails on existing metadata
`loadSeriesMetadata` now uses an upsert pattern: if `CreateSeriesMetadata` fails (e.g., UNIQUE constraint violation), it falls back to fetching and updating the existing record. This preserves the season/episode discovery logic while handling existing series metadata.

### #132 — Duplicate episode result builder
Extracted `buildEpisodeResult` and `resolveEpisodeMetadata` helpers, eliminating ~60 lines of duplicated episode-to-result transformation logic between `getEpisodesForSeason` and `ListEpisodesForSeason`.

## Test Plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` passes
- [x] `gofmt` shows no formatting issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved potential crash when handling empty series search results
  * Improved metadata creation/update flow to reliably reuse existing records on conflicts
  * Fixed external metadata handling to prevent response/body lifecycle issues

* **Refactor**
  * Streamlined episode result construction and switched to batch metadata loading for better performance and memory use
<!-- end of auto-generated comment: release notes by coderabbit.ai -->