### PR TITLE
Fix: AddMovieToLibrary checks existing movie state

### DIFF
--- a/pkg/manager/movie_service.go
+++ b/pkg/manager/movie_service.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// ErrMovieAlreadyExists is returned when adding a movie that already exists
+// in a terminal or in-progress state (downloaded or downloading).
+var ErrMovieAlreadyExists = errors.New("movie already exists in library")
+
 // MovieMetadataProvider provides movie metadata operations needed by MovieService.
 // This decouples MovieService from the full MediaManager, allowing the metadata
 // subsystem to be extracted independently later.
@@ -49,7 +53,9 @@ func NewMovieService(tmdbClient tmdb.ITmdb, lib library.Library, movieStorage st
 // ---------------------------------------------------------------------------
 
 // AddMovieToLibrary adds a movie to be managed by mediaz.
-// TODO: check status of movie before doing anything else.. do we already have it tracked? is it downloaded or already discovered? error state?
+// If the movie already exists and is in a downloaded or downloading state it returns
+// the movie alongside ErrMovieAlreadyExists. Movies in discovered, missing, unreleased,
+// or new states are returned without error — they still need reconciliation.
 func (s *MovieService) AddMovieToLibrary(ctx context.Context, request AddMovieRequest) (*storage.Movie, error) {
 	log := logger.FromCtx(ctx)
 
@@ -66,9 +72,23 @@ func (s *MovieService) AddMovieToLibrary(ctx context.Context, request AddMovieRe
 	}
 
 	movie, err := s.movieStorage.GetMovieByMetadataID(ctx, int(det.ID))
-	// if we find the movie we're done
 	if err == nil {
-		return movie, err
+		// Movie already exists — check its state before deciding what to return.
+		switch movie.State {
+		case storage.MovieStateDownloaded, storage.MovieStateDownloading:
+			log.Debug("movie already exists in library",
+				zap.Int32("movie_id", movie.ID),
+				zap.String("state", string(movie.State)),
+			)
+			return movie, ErrMovieAlreadyExists
+		default:
+			// discovered, missing, unreleased, new — still needs processing
+			log.Debug("movie exists but still needs reconciliation",
+				zap.Int32("movie_id", movie.ID),
+				zap.String("state", string(movie.State)),
+			)
+			return movie, nil
+		}
 	}
 
 	// anything other than a not found error is an internal error

--- a/pkg/manager/movie_service_test.go
+++ b/pkg/manager/movie_service_test.go
@@ -122,7 +122,7 @@ func TestMovieService_AddMovieToLibrary(t *testing.T) {
 	assert.Equal(t, expected, movie)
 }
 
-func TestMovieService_AddMovieToLibrary_AlreadyExists(t *testing.T) {
+func TestMovieService_AddMovieToLibrary_AlreadyExists_Downloaded(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -149,7 +149,8 @@ func TestMovieService_AddMovieToLibrary_AlreadyExists(t *testing.T) {
 	}, nil)
 
 	movie, err := svc.AddMovieToLibrary(ctx, AddMovieRequest{TMDBID: 1234, QualityProfileID: 1})
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMovieAlreadyExists))
 	require.NotNil(t, movie)
 
 	expected := &storage.Movie{
@@ -160,6 +161,175 @@ func TestMovieService_AddMovieToLibrary_AlreadyExists(t *testing.T) {
 			QualityProfileID: 1,
 		},
 		State: storage.MovieStateDownloaded,
+	}
+	assert.Equal(t, expected, movie)
+}
+
+func TestMovieService_AddMovieToLibrary_AlreadyExists_Downloading(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	svc, store, _, _ := newTestMovieService(ctrl)
+
+	metadata := &model.MovieMetadata{
+		ID:     1,
+		TmdbID: 1234,
+		Title:  "Downloading Movie",
+	}
+
+	svc.metadataProvider = &mockMovieMetadataProvider{metadata: metadata}
+
+	store.EXPECT().GetQualityProfile(ctx, int64(1)).Return(storage.QualityProfile{ID: 1}, nil)
+	store.EXPECT().GetMovieByMetadataID(ctx, 1).Return(&storage.Movie{
+		Movie: model.Movie{
+			ID:               6,
+			MovieMetadataID:  ptr.To(int32(1)),
+			Monitored:        1,
+			QualityProfileID: 1,
+		},
+		State: storage.MovieStateDownloading,
+	}, nil)
+
+	movie, err := svc.AddMovieToLibrary(ctx, AddMovieRequest{TMDBID: 1234, QualityProfileID: 1})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMovieAlreadyExists))
+	require.NotNil(t, movie)
+
+	expected := &storage.Movie{
+		Movie: model.Movie{
+			ID:               6,
+			MovieMetadataID:  ptr.To(int32(1)),
+			Monitored:        1,
+			QualityProfileID: 1,
+		},
+		State: storage.MovieStateDownloading,
+	}
+	assert.Equal(t, expected, movie)
+}
+
+func TestMovieService_AddMovieToLibrary_AlreadyExists_Discovered(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	svc, store, _, _ := newTestMovieService(ctrl)
+
+	metadata := &model.MovieMetadata{
+		ID:     1,
+		TmdbID: 1234,
+		Title:  "Discovered Movie",
+	}
+
+	svc.metadataProvider = &mockMovieMetadataProvider{metadata: metadata}
+
+	store.EXPECT().GetQualityProfile(ctx, int64(1)).Return(storage.QualityProfile{ID: 1}, nil)
+	store.EXPECT().GetMovieByMetadataID(ctx, 1).Return(&storage.Movie{
+		Movie: model.Movie{
+			ID:               7,
+			MovieMetadataID:  ptr.To(int32(1)),
+			Monitored:        1,
+			QualityProfileID: 1,
+		},
+		State: storage.MovieStateDiscovered,
+	}, nil)
+
+	movie, err := svc.AddMovieToLibrary(ctx, AddMovieRequest{TMDBID: 1234, QualityProfileID: 1})
+	require.NoError(t, err)
+	require.NotNil(t, movie)
+
+	expected := &storage.Movie{
+		Movie: model.Movie{
+			ID:               7,
+			MovieMetadataID:  ptr.To(int32(1)),
+			Monitored:        1,
+			QualityProfileID: 1,
+		},
+		State: storage.MovieStateDiscovered,
+	}
+	assert.Equal(t, expected, movie)
+}
+
+func TestMovieService_AddMovieToLibrary_AlreadyExists_Missing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	svc, store, _, _ := newTestMovieService(ctrl)
+
+	metadata := &model.MovieMetadata{
+		ID:     1,
+		TmdbID: 1234,
+		Title:  "Missing Movie",
+	}
+
+	svc.metadataProvider = &mockMovieMetadataProvider{metadata: metadata}
+
+	store.EXPECT().GetQualityProfile(ctx, int64(1)).Return(storage.QualityProfile{ID: 1}, nil)
+	store.EXPECT().GetMovieByMetadataID(ctx, 1).Return(&storage.Movie{
+		Movie: model.Movie{
+			ID:               8,
+			MovieMetadataID:  ptr.To(int32(1)),
+			Monitored:        1,
+			QualityProfileID: 1,
+		},
+		State: storage.MovieStateMissing,
+	}, nil)
+
+	movie, err := svc.AddMovieToLibrary(ctx, AddMovieRequest{TMDBID: 1234, QualityProfileID: 1})
+	require.NoError(t, err)
+	require.NotNil(t, movie)
+
+	expected := &storage.Movie{
+		Movie: model.Movie{
+			ID:               8,
+			MovieMetadataID:  ptr.To(int32(1)),
+			Monitored:        1,
+			QualityProfileID: 1,
+		},
+		State: storage.MovieStateMissing,
+	}
+	assert.Equal(t, expected, movie)
+}
+
+func TestMovieService_AddMovieToLibrary_AlreadyExists_Unreleased(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	svc, store, _, _ := newTestMovieService(ctrl)
+
+	metadata := &model.MovieMetadata{
+		ID:     1,
+		TmdbID: 1234,
+		Title:  "Unreleased Movie",
+	}
+
+	svc.metadataProvider = &mockMovieMetadataProvider{metadata: metadata}
+
+	store.EXPECT().GetQualityProfile(ctx, int64(1)).Return(storage.QualityProfile{ID: 1}, nil)
+	store.EXPECT().GetMovieByMetadataID(ctx, 1).Return(&storage.Movie{
+		Movie: model.Movie{
+			ID:               9,
+			MovieMetadataID:  ptr.To(int32(1)),
+			Monitored:        1,
+			QualityProfileID: 1,
+		},
+		State: storage.MovieStateUnreleased,
+	}, nil)
+
+	movie, err := svc.AddMovieToLibrary(ctx, AddMovieRequest{TMDBID: 1234, QualityProfileID: 1})
+	require.NoError(t, err)
+	require.NotNil(t, movie)
+
+	expected := &storage.Movie{
+		Movie: model.Movie{
+			ID:               9,
+			MovieMetadataID:  ptr.To(int32(1)),
+			Monitored:        1,
+			QualityProfileID: 1,
+		},
+		State: storage.MovieStateUnreleased,
 	}
 	assert.Equal(t, expected, movie)
 }

--- a/server/movie_handlers.go
+++ b/server/movie_handlers.go
@@ -10,6 +10,12 @@ import (
 	"go.uber.org/zap"
 )
 
+// isMovieAlreadyExists returns true if the error indicates the movie already
+// exists in the library.
+func isMovieAlreadyExists(err error) bool {
+	return errors.Is(err, manager.ErrMovieAlreadyExists)
+}
+
 // ListMovies lists movies on disk
 func (s Server) ListMovies() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +59,12 @@ func (s Server) AddMovieToLibrary() http.HandlerFunc {
 
 		release, err := s.manager.AddMovieToLibrary(r.Context(), req)
 		if err != nil {
+			if isMovieAlreadyExists(err) {
+				log := logger.FromCtx(r.Context())
+				log.Debug("movie already exists in library", zap.Int("tmdbID", req.TMDBID))
+				s.respond(r, w, http.StatusConflict, release)
+				return
+			}
 			s.respondError(r, w, http.StatusInternalServerError, err)
 			return
 		}

--- a/server/movie_handlers_test.go
+++ b/server/movie_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -194,5 +195,267 @@ func TestServer_GetMovieDetailByTMDBID(t *testing.T) {
 		responseBody := rr.Body.String()
 		assert.Contains(t, responseBody, "error")
 		assert.Contains(t, responseBody, "null") // response should be null when there's an error
+	})
+}
+
+func TestServer_AddMovieToLibrary(t *testing.T) {
+	t.Run("success - new movie", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		store := storeMocks.NewMockStorage(ctrl)
+		tmdbMock := tmdbMocks.NewMockITmdb(ctrl)
+
+		releaseDate := time.Now().AddDate(0, 0, -1)
+		metadata := &model.MovieMetadata{
+			ID:          1,
+			TmdbID:      1234,
+			Title:       "Test Movie",
+			ReleaseDate: &releaseDate,
+		}
+
+		store.EXPECT().GetQualityProfile(gomock.Any(), int64(1)).Return(storage.QualityProfile{ID: 1}, nil)
+		store.EXPECT().GetMovieMetadata(gomock.Any(), gomock.Any()).Return(metadata, nil)
+		store.EXPECT().GetMovieByMetadataID(gomock.Any(), 1).Return(nil, storage.ErrNotFound)
+		store.EXPECT().CreateMovie(gomock.Any(), gomock.Any(), storage.MovieStateMissing).Return(int64(1), nil)
+		store.EXPECT().GetMovie(gomock.Any(), int64(1)).Return(&storage.Movie{
+			Movie: model.Movie{
+				ID:               1,
+				Monitored:        1,
+				QualityProfileID: 1,
+				MovieMetadataID:  ptr.To(int32(1)),
+				Path:             ptr.To("Test Movie"),
+			},
+			State: storage.MovieStateMissing,
+		}, nil)
+
+		mgr := manager.New(tmdbMock, nil, nil, store, nil, config.Manager{}, config.Config{})
+		s := newTestServer(withManager(mgr))
+
+		body := `{"tmdbId": 1234, "qualityProfileId": 1}`
+		req, err := http.NewRequest("POST", "/library/movies", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		router := mux.NewRouter()
+		router.HandleFunc("/library/movies", s.AddMovieToLibrary()).Methods("POST")
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response GenericResponse
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		movieData, ok := response.Response.(map[string]any)
+		require.True(t, ok, "Response should contain movie data")
+		assert.Equal(t, float64(1), movieData["ID"])
+		assert.Equal(t, "missing", movieData["state"])
+		assert.Equal(t, float64(1), movieData["Monitored"])
+		assert.Equal(t, float64(1), movieData["QualityProfileID"])
+	})
+
+	t.Run("conflict - movie already downloaded", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		store := storeMocks.NewMockStorage(ctrl)
+		tmdbMock := tmdbMocks.NewMockITmdb(ctrl)
+
+		metadata := &model.MovieMetadata{
+			ID:     1,
+			TmdbID: 1234,
+			Title:  "Existing Movie",
+		}
+
+		store.EXPECT().GetQualityProfile(gomock.Any(), int64(1)).Return(storage.QualityProfile{ID: 1}, nil)
+		store.EXPECT().GetMovieMetadata(gomock.Any(), gomock.Any()).Return(metadata, nil)
+		store.EXPECT().GetMovieByMetadataID(gomock.Any(), 1).Return(&storage.Movie{
+			Movie: model.Movie{
+				ID:               5,
+				MovieMetadataID:  ptr.To(int32(1)),
+				Monitored:        1,
+				QualityProfileID: 1,
+			},
+			State: storage.MovieStateDownloaded,
+		}, nil)
+
+		mgr := manager.New(tmdbMock, nil, nil, store, nil, config.Manager{}, config.Config{})
+		s := newTestServer(withManager(mgr))
+
+		body := `{"tmdbId": 1234, "qualityProfileId": 1}`
+		req, err := http.NewRequest("POST", "/library/movies", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		router := mux.NewRouter()
+		router.HandleFunc("/library/movies", s.AddMovieToLibrary()).Methods("POST")
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusConflict, rr.Code)
+
+		var response GenericResponse
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		movieData, ok := response.Response.(map[string]any)
+		require.True(t, ok, "Response should contain the existing movie")
+		assert.Equal(t, float64(5), movieData["ID"])
+		assert.Equal(t, "downloaded", movieData["state"])
+		assert.Equal(t, float64(1), movieData["Monitored"])
+		assert.Equal(t, float64(1), movieData["QualityProfileID"])
+	})
+
+	t.Run("conflict - movie downloading", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		store := storeMocks.NewMockStorage(ctrl)
+		tmdbMock := tmdbMocks.NewMockITmdb(ctrl)
+
+		metadata := &model.MovieMetadata{
+			ID:     1,
+			TmdbID: 1234,
+			Title:  "Downloading Movie",
+		}
+
+		store.EXPECT().GetQualityProfile(gomock.Any(), int64(1)).Return(storage.QualityProfile{ID: 1}, nil)
+		store.EXPECT().GetMovieMetadata(gomock.Any(), gomock.Any()).Return(metadata, nil)
+		store.EXPECT().GetMovieByMetadataID(gomock.Any(), 1).Return(&storage.Movie{
+			Movie: model.Movie{
+				ID:               6,
+				MovieMetadataID:  ptr.To(int32(1)),
+				Monitored:        1,
+				QualityProfileID: 1,
+			},
+			State: storage.MovieStateDownloading,
+		}, nil)
+
+		mgr := manager.New(tmdbMock, nil, nil, store, nil, config.Manager{}, config.Config{})
+		s := newTestServer(withManager(mgr))
+
+		body := `{"tmdbId": 1234, "qualityProfileId": 1}`
+		req, err := http.NewRequest("POST", "/library/movies", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		router := mux.NewRouter()
+		router.HandleFunc("/library/movies", s.AddMovieToLibrary()).Methods("POST")
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusConflict, rr.Code)
+
+		var response GenericResponse
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		movieData, ok := response.Response.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, float64(6), movieData["ID"])
+		assert.Equal(t, "downloading", movieData["state"])
+		assert.Equal(t, float64(1), movieData["Monitored"])
+		assert.Equal(t, float64(1), movieData["QualityProfileID"])
+	})
+
+	t.Run("ok - movie exists in discovered state", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		store := storeMocks.NewMockStorage(ctrl)
+		tmdbMock := tmdbMocks.NewMockITmdb(ctrl)
+
+		metadata := &model.MovieMetadata{
+			ID:     1,
+			TmdbID: 1234,
+			Title:  "Discovered Movie",
+		}
+
+		store.EXPECT().GetQualityProfile(gomock.Any(), int64(1)).Return(storage.QualityProfile{ID: 1}, nil)
+		store.EXPECT().GetMovieMetadata(gomock.Any(), gomock.Any()).Return(metadata, nil)
+		store.EXPECT().GetMovieByMetadataID(gomock.Any(), 1).Return(&storage.Movie{
+			Movie: model.Movie{
+				ID:               7,
+				MovieMetadataID:  ptr.To(int32(1)),
+				Monitored:        1,
+				QualityProfileID: 1,
+			},
+			State: storage.MovieStateDiscovered,
+		}, nil)
+
+		mgr := manager.New(tmdbMock, nil, nil, store, nil, config.Manager{}, config.Config{})
+		s := newTestServer(withManager(mgr))
+
+		body := `{"tmdbId": 1234, "qualityProfileId": 1}`
+		req, err := http.NewRequest("POST", "/library/movies", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		router := mux.NewRouter()
+		router.HandleFunc("/library/movies", s.AddMovieToLibrary()).Methods("POST")
+		router.ServeHTTP(rr, req)
+
+		// Discovered movies still need reconciliation, so 200 is correct
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		var response GenericResponse
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		movieData, ok := response.Response.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, float64(7), movieData["ID"])
+		assert.Equal(t, "discovered", movieData["state"])
+		assert.Equal(t, float64(1), movieData["Monitored"])
+		assert.Equal(t, float64(1), movieData["QualityProfileID"])
+	})
+
+	t.Run("bad request - invalid body", func(t *testing.T) {
+		s := newTestServer()
+
+		req, err := http.NewRequest("POST", "/library/movies", strings.NewReader("not json"))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		router := mux.NewRouter()
+		router.HandleFunc("/library/movies", s.AddMovieToLibrary()).Methods("POST")
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("internal error - quality profile not found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		store := storeMocks.NewMockStorage(ctrl)
+		tmdbMock := tmdbMocks.NewMockITmdb(ctrl)
+
+		store.EXPECT().GetQualityProfile(gomock.Any(), int64(99)).Return(storage.QualityProfile{}, errors.New("not found"))
+
+		mgr := manager.New(tmdbMock, nil, nil, store, nil, config.Manager{}, config.Config{})
+		s := newTestServer(withManager(mgr))
+
+		body := `{"tmdbId": 1234, "qualityProfileId": 99}`
+		req, err := http.NewRequest("POST", "/library/movies", strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		rr := httptest.NewRecorder()
+		router := mux.NewRouter()
+		router.HandleFunc("/library/movies", s.AddMovieToLibrary()).Methods("POST")
+		router.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+		var response GenericResponse
+		err = json.Unmarshal(rr.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Nil(t, response.Response)
+		assert.NotEmpty(t, response.Error)
 	})
 }


### PR DESCRIPTION
## Summary

`AddMovieToLibrary` now inspects the state of an existing movie before returning it, instead of silently returning regardless of state.

Fixes #150
Fixes #163

## Changes

- **`pkg/manager/movie_service.go`**: Added `ErrMovieAlreadyExists` sentinel error. When a movie already exists, its state is now inspected:
  - `Downloaded` / `Downloading` → returns `(movie, ErrMovieAlreadyExists)` (terminal/in-progress, re-adding makes no sense)
  - `Discovered` / `Missing` / `Unreleased` / `New` → returns `(movie, nil)` (still needs reconciliation)
  - Removed the TODO comment that prompted this work

- **`server/movie_handlers.go`**: Added `isMovieAlreadyExists` helper. Handler returns **409 Conflict** with the movie data when `ErrMovieAlreadyExists` is received, instead of 500.

- **`pkg/manager/movie_service_test.go`**: Replaced single `AlreadyExists` test with 5 per-state tests covering Downloaded, Downloading, Discovered, Missing, and Unreleased.

- **`server/movie_handlers_test.go`**: Added 6 handler-level tests for the `AddMovieToLibrary` endpoint covering success, conflict (downloaded), conflict (downloading), existing discovered (200), bad request, and internal error cases.

## Test Plan
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` is clean
- [x] New service-level tests for each movie state
- [x] New handler-level tests for HTTP status codes and response bodies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error responses when adding duplicate movies to the library. The system now returns HTTP 409 Conflict for movies already downloaded or currently downloading, providing clearer user feedback instead of generic errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kasuboski/mediaz/pull/168)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->