### PR TITLE
fix: transition movie to Downloaded when MovieFileID already exists during reconcile

### DIFF
--- a/pkg/manager/movie_reconcile.go
+++ b/pkg/manager/movie_reconcile.go
@@ -233,9 +233,8 @@ func (m MediaManager) reconcileMissingMovie(ctx context.Context, movie *storage.
 	}
 
 	if movie.MovieFileID != nil {
-		// TODO: should this update state? If we have a movie ID we don't need to download the actual file most likely
-		log.Debug("movie file id already exists for movie, skipping reconcile")
-		return nil
+		log.Debug("movie file already exists, transitioning to downloaded")
+		return m.updateMovieState(ctx, movie, storage.MovieStateDownloaded, nil)
 	}
 
 	det, err := m.movieMetaStorage.GetMovieMetadata(ctx, table.MovieMetadata.ID.EQ(sqlite.Int32(*movie.MovieMetadataID)))

--- a/pkg/manager/movie_reconcile_test.go
+++ b/pkg/manager/movie_reconcile_test.go
@@ -892,3 +892,64 @@ func Test_Manager_reconcileDownloadingMovie(t *testing.T) {
 	})
 }
 
+func Test_Manager_reconcileMissingMovie_MovieFileIDAlreadySet(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t, ctx)
+
+	m := New(nil, nil, nil, store, nil, config.Manager{}, config.Config{})
+	require.NotNil(t, m)
+
+	// Create movie metadata so we can link the movie
+	metaID, err := store.CreateMovieMetadata(ctx, model.MovieMetadata{
+		Title:  "test-movie",
+		TmdbID: 1234,
+	})
+	require.NoError(t, err)
+
+	// Create a movie in Missing state with metadata linked
+	movieID, err := m.movieStorage.CreateMovie(ctx, storage.Movie{
+		Movie: model.Movie{
+			Monitored:        1,
+			QualityProfileID: 1,
+			Path:             ptr.To("test-movie"),
+			MovieMetadataID:  ptr.To(int32(metaID)),
+		},
+	}, storage.MovieStateMissing)
+	require.NoError(t, err)
+
+	// Create a movie file and link it to the movie
+	fileID, err := store.CreateMovieFile(ctx, model.MovieFile{
+		RelativePath:     ptr.To("test-movie/test-movie.mkv"),
+		Size:             2048,
+		OriginalFilePath: ptr.To("/downloads/test-movie.mkv"),
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateMovieMovieFileID(ctx, movieID, fileID)
+	require.NoError(t, err)
+
+	// Get the movie with the file ID set
+	movie, err := store.GetMovie(ctx, movieID)
+	require.NoError(t, err)
+	require.NotNil(t, movie.MovieFileID, "MovieFileID should be set")
+	assert.Equal(t, storage.MovieStateMissing, movie.State, "movie should start in missing state")
+
+	// Reconcile the missing movie
+	snapshot := newReconcileSnapshot(nil, nil)
+	err = m.reconcileMissingMovie(ctx, movie, snapshot)
+	require.NoError(t, err)
+
+	// Verify the movie is now in Downloaded state with all fields preserved
+	mov, err := store.GetMovie(ctx, movieID)
+	require.NoError(t, err)
+	assert.Equal(t, storage.MovieStateDownloaded, mov.State)
+	assert.Equal(t, int32(1), mov.Monitored)
+	assert.Equal(t, int32(1), mov.QualityProfileID)
+	assert.NotNil(t, mov.MovieFileID)
+	assert.Equal(t, int32(fileID), *mov.MovieFileID)
+	assert.NotNil(t, mov.MovieMetadataID)
+	assert.Equal(t, int32(metaID), *mov.MovieMetadataID)
+	assert.NotNil(t, mov.Path)
+	assert.Equal(t, "test-movie", *mov.Path)
+}
+

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -100,7 +100,7 @@ type MovieTransition model.MovieTransition
 func (m Movie) Machine() *machine.StateMachine[MovieState] {
 	return machine.New(m.State,
 		machine.From(MovieStateNew).To(MovieStateUnreleased, MovieStateMissing, MovieStateDiscovered),
-		machine.From(MovieStateMissing).To(MovieStateDiscovered, MovieStateDownloading),
+		machine.From(MovieStateMissing).To(MovieStateDiscovered, MovieStateDownloading, MovieStateDownloaded),
 		machine.From(MovieStateUnreleased).To(MovieStateDiscovered, MovieStateMissing),
 		machine.From(MovieStateDownloading).To(MovieStateDownloaded),
 	)


### PR DESCRIPTION
## What

When a movie in `Missing` state already has a `MovieFileID`, the reconcile loop was skipping it with a TODO comment. This left movies stuck in `Missing` forever even though their files were already tracked.

## Changes

- Add `Missing → Downloaded` transition to the movie state machine (`pkg/storage/storage.go`)
- Replace TODO + skip with `updateMovieState` to `Downloaded` (`pkg/manager/movie_reconcile.go`)
- Add test asserting state transition and that all fields are preserved through the transition

## Why not go through Downloading?

Going through `Downloading` as an intermediate would be semantically wrong (nothing is being downloaded) and would trigger another reconcile loop unnecessarily. The file already exists — this is a state correction, not a new download.

Fixes #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved movie file reconciliation to correctly handle cases where movies already have associated files, ensuring proper state transitions and preserving critical file information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kasuboski/mediaz/pull/169)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->