### PR TITLE
Fix: Aggregate reconcile errors instead of silently swallowing them

### DIFF
--- a/pkg/manager/movie_reconcile.go
+++ b/pkg/manager/movie_reconcile.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -33,27 +34,33 @@ func (m MediaManager) ReconcileMovies(ctx context.Context) error {
 
 	snapshot := newReconcileSnapshot(make([]model.Indexer, 0), dcs)
 
+	var allErrors error
+
 	err = m.ReconcileMissingMovies(ctx, snapshot)
 	if err != nil {
 		log.Error("failed to reconcile missing movies", zap.Error(err))
+		allErrors = errors.Join(allErrors, err)
 	}
 
 	err = m.ReconcileUnreleasedMovies(ctx, snapshot)
 	if err != nil {
 		log.Error("failed to reconcile unreleased movies", zap.Error(err))
+		allErrors = errors.Join(allErrors, err)
 	}
 
 	err = m.ReconcileDownloadingMovies(ctx, snapshot)
 	if err != nil {
 		log.Error("failed to reconcile downloading movies", zap.Error(err))
+		allErrors = errors.Join(allErrors, err)
 	}
 
 	err = m.ReconcileDiscoveredMovies(ctx, snapshot)
 	if err != nil {
 		log.Error("failed to reconcile discovered movies", zap.Error(err))
+		allErrors = errors.Join(allErrors, err)
 	}
 
-	return nil
+	return allErrors
 }
 
 func (m MediaManager) ReconcileMissingMovies(ctx context.Context, snapshot *ReconcileSnapshot) error {

--- a/pkg/manager/movie_reconcile_test.go
+++ b/pkg/manager/movie_reconcile_test.go
@@ -953,3 +953,62 @@ func Test_Manager_reconcileMissingMovie_MovieFileIDAlreadySet(t *testing.T) {
 	assert.Equal(t, "test-movie", *mov.Path)
 }
 
+func Test_Manager_ReconcileMovies(t *testing.T) {
+	t.Run("returns nil when all sub-reconcilers succeed", func(t *testing.T) {
+		ctx := context.Background()
+		store := newStore(t, ctx)
+
+		m := New(nil, nil, nil, store, nil, config.Manager{}, config.Config{})
+		require.NotNil(t, m)
+
+		err := m.ReconcileMovies(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error when ListDownloadClients fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
+
+		store := storageMocks.NewMockStorage(ctrl)
+		store.EXPECT().ListDownloadClients(ctx).Return(nil, errors.New("download client error"))
+
+		m := New(nil, nil, nil, store, nil, config.Manager{}, config.Config{})
+		require.NotNil(t, m)
+
+		err := m.ReconcileMovies(ctx)
+		assert.Error(t, err)
+		assert.Equal(t, "download client error", err.Error())
+	})
+
+	t.Run("aggregates errors from multiple sub-reconcilers", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
+
+		store := storageMocks.NewMockStorage(ctrl)
+
+		// ListDownloadClients succeeds
+		store.EXPECT().ListDownloadClients(ctx).Return(nil, nil)
+
+		// ReconcileMissingMovies: listIndexersInternal calls ListIndexers → fails
+		store.EXPECT().ListIndexers(gomock.Any()).Return(nil, errors.New("indexer error")).AnyTimes()
+
+		// ReconcileUnreleasedMovies: ListMoviesByState for unreleased
+		store.EXPECT().ListMoviesByState(gomock.Any(), storage.MovieStateUnreleased).Return(nil, errors.New("unreleased error")).AnyTimes()
+
+		// ReconcileDownloadingMovies: ListMoviesByState for downloading → succeeds with empty
+		store.EXPECT().ListMoviesByState(gomock.Any(), storage.MovieStateDownloading).Return(nil, nil).AnyTimes()
+
+		// ReconcileDiscoveredMovies: ListMoviesByState for discovered → succeeds with empty
+		store.EXPECT().ListMoviesByState(gomock.Any(), storage.MovieStateDiscovered).Return(nil, nil).AnyTimes()
+
+		m := New(nil, nil, nil, store, nil, config.Manager{}, config.Config{})
+		require.NotNil(t, m)
+
+		err := m.ReconcileMovies(ctx)
+		assert.Error(t, err)
+		// errors.Join wraps multiple errors; both messages should be present
+		assert.Contains(t, err.Error(), "indexer error")
+		assert.Contains(t, err.Error(), "unreleased error")
+	})
+}
+

--- a/pkg/manager/series_reconcile.go
+++ b/pkg/manager/series_reconcile.go
@@ -30,37 +30,45 @@ func (m MediaManager) ReconcileSeries(ctx context.Context) error {
 
 	snapshot := newReconcileSnapshot(make([]model.Indexer, 0), dcs)
 
+	var allErrors error
+
 	err = m.ReconcileMissingSeries(ctx, snapshot)
 	if err != nil {
 		log.Error("failed to reconcile missing series", zap.Error(err))
+		allErrors = errors.Join(allErrors, err)
 	}
 
 	err = m.ReconcileDownloadingSeries(ctx, snapshot)
 	if err != nil {
 		log.Error("failed to reconcile downloading series", zap.Error(err))
+		allErrors = errors.Join(allErrors, err)
 	}
 
 	err = m.ReconcileContinuingSeries(ctx, snapshot)
 	if err != nil {
 		log.Error("failed to reconcile continuing series", zap.Error(err))
+		allErrors = errors.Join(allErrors, err)
 	}
 
 	err = m.ReconcileCompletedSeasons(ctx)
 	if err != nil {
 		log.Error("failed to reconcile completed seasons", zap.Error(err))
+		allErrors = errors.Join(allErrors, err)
 	}
 
 	err = m.ReconcileCompletedSeries(ctx)
 	if err != nil {
 		log.Error("failed to reconcile completed series", zap.Error(err))
+		allErrors = errors.Join(allErrors, err)
 	}
 
 	err = m.ReconcileDiscoveredEpisodes(ctx, snapshot)
 	if err != nil {
 		log.Error("failed to reconcile discovered episodes", zap.Error(err))
+		allErrors = errors.Join(allErrors, err)
 	}
 
-	return nil
+	return allErrors
 }
 
 func (m MediaManager) ReconcileMissingSeries(ctx context.Context, snapshot *ReconcileSnapshot) error {

--- a/pkg/manager/series_reconcile_test.go
+++ b/pkg/manager/series_reconcile_test.go
@@ -1659,3 +1659,63 @@ func TestMediaManager_matchEpisodeFileToEpisode(t *testing.T) {
 	})
 }
 
+func Test_Manager_ReconcileSeries(t *testing.T) {
+	t.Run("returns nil when all sub-reconcilers succeed", func(t *testing.T) {
+		ctx := context.Background()
+		store := newStore(t, ctx)
+
+		m := New(nil, nil, nil, store, nil, config.Manager{}, config.Config{})
+		require.NotNil(t, m)
+
+		err := m.ReconcileSeries(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns error when ListDownloadClients fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
+
+		store := storageMocks.NewMockStorage(ctrl)
+		store.EXPECT().ListDownloadClients(ctx).Return(nil, errors.New("download client error"))
+
+		m := New(nil, nil, nil, store, nil, config.Manager{}, config.Config{})
+		require.NotNil(t, m)
+
+		err := m.ReconcileSeries(ctx)
+		assert.Error(t, err)
+		assert.Equal(t, "download client error", err.Error())
+	})
+
+	t.Run("aggregates errors from multiple sub-reconcilers", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
+
+		store := storageMocks.NewMockStorage(ctrl)
+
+		// ListDownloadClients succeeds
+		store.EXPECT().ListDownloadClients(ctx).Return(nil, nil)
+
+		// ReconcileMissingSeries: listIndexersInternal → ListIndexers fails
+		store.EXPECT().ListIndexers(gomock.Any()).Return(nil, errors.New("indexer error")).AnyTimes()
+
+		// ReconcileDownloadingSeries: ListEpisodes fails
+		store.EXPECT().ListEpisodes(gomock.Any(), gomock.Any()).Return(nil, errors.New("episodes error")).AnyTimes()
+
+		// ReconcileContinuingSeries: ListSeries succeeds with empty
+		store.EXPECT().ListSeries(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+		// ReconcileCompletedSeasons: ListSeasons succeeds with empty
+		store.EXPECT().ListSeasons(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+		m := New(nil, nil, nil, store, nil, config.Manager{}, config.Config{})
+		require.NotNil(t, m)
+
+		err := m.ReconcileSeries(ctx)
+		assert.Error(t, err)
+		// errors.Join wraps multiple errors; both messages should be present
+		errStr := err.Error()
+		assert.Contains(t, errStr, "indexer error")
+		assert.Contains(t, errStr, "episodes error")
+	})
+}
+


### PR DESCRIPTION
Parent: #126. Closes #133.

## Problem

Both ReconcileMovies and ReconcileSeries called sub-reconcilers sequentially, logged errors, then overwrote the error variable and always returned nil. The scheduler had zero visibility into reconciliation failures.

## Fix

Use errors.Join to aggregate errors from each sub-reconciler while preserving the log-and-continue behavior (each sub-reconciler still runs independently even if earlier ones fail).

## Files Changed
- pkg/manager/movie_reconcile.go - ReconcileMovies aggregates errors via errors.Join
- pkg/manager/series_reconcile.go - ReconcileSeries aggregates errors via errors.Join
- pkg/manager/movie_reconcile_test.go - Added Test_Manager_ReconcileMovies (3 subtests)
- pkg/manager/series_reconcile_test.go - Added Test_Manager_ReconcileSeries (3 subtests)

## Testing
- All existing tests pass
- New tests verify error aggregation across sub-reconcilers
- go vet ./... is clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting for movie and series reconciliation processes. The system now properly aggregates and returns errors encountered during reconciliation, providing better visibility into failures instead of silently continuing.

* **Tests**
  * Added comprehensive test coverage for reconciliation error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kasuboski/mediaz/pull/170)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->