### PR TITLE
fix: add per-source timeout to SearchIndexers goroutines

### DIFF
--- a/pkg/manager/indexer_service.go
+++ b/pkg/manager/indexer_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"time"
 
 	"github.com/go-jet/jet/v2/sqlite"
 	"github.com/kasuboski/mediaz/pkg/cache"
@@ -386,6 +387,12 @@ func (is IndexerService) RefreshAllIndexerSources(ctx context.Context) error {
 	return allErrors
 }
 
+// sourceSearchTimeout is the per-source timeout for indexer search operations.
+// If any single source goroutine exceeds this duration it is cancelled and
+// its timeout error is aggregated with any other source errors, preventing a
+// slow or unresponsive source from hanging the entire SearchIndexers call.
+const sourceSearchTimeout = 30 * time.Second
+
 func (is IndexerService) SearchIndexers(ctx context.Context, indexers, categories []int32, opts indexer.SearchOptions) ([]*prowlarr.ReleaseResource, error) {
 	log := logger.FromCtx(ctx)
 
@@ -423,7 +430,9 @@ func (is IndexerService) SearchIndexers(ctx context.Context, indexers, categorie
 		wg.Add(1)
 		go func(srcID int64, indexerIDs []int32) {
 			defer wg.Done()
-			releases, err := is.searchIndexerSource(ctx, srcID, indexerIDs, categories, opts)
+			ctxWithTimeout, cancel := context.WithTimeout(ctx, sourceSearchTimeout)
+			defer cancel()
+			releases, err := is.searchIndexerSource(ctxWithTimeout, srcID, indexerIDs, categories, opts)
 			resultChan <- result{releases: releases, err: err}
 		}(sourceID, idxIDs)
 	}

--- a/pkg/manager/indexer_service_test.go
+++ b/pkg/manager/indexer_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/kasuboski/mediaz/pkg/indexer"
 	indexerMock "github.com/kasuboski/mediaz/pkg/indexer/mocks"
@@ -721,18 +722,100 @@ func TestIndexerService_SearchIndexers(t *testing.T) {
 		svc, _, srcStorage, factory := newTestIndexerService(ctrl)
 
 		src := indexerMock.NewMockIndexerSource(ctrl)
+		// RefreshIndexerSource call
 		srcStorage.EXPECT().GetIndexerSource(ctx, int64(1)).Return(model.IndexerSource{
 			ID: 1, Name: "prowlarr", Scheme: "http", Host: "prowlarr-host", Enabled: true,
-		}, nil).Times(2)
-		factory.EXPECT().NewIndexerSource(gomock.Any()).Return(src, nil).Times(2)
+		}, nil)
+		factory.EXPECT().NewIndexerSource(gomock.Any()).Return(src, nil)
 		src.EXPECT().ListIndexers(ctx).Return([]indexer.SourceIndexer{{ID: 1, Name: "indexer-1"}}, nil)
 		require.NoError(t, svc.RefreshIndexerSource(ctx, 1))
 
 		want := []*prowlarr.ReleaseResource{{Title: nullable.NewNullableWithValue("Test Movie")}}
-		src.EXPECT().Search(ctx, int32(1), gomock.Any(), gomock.Any()).Return(want, nil)
+		// searchIndexerSource call (goroutine uses timeout-wrapped context)
+		srcStorage.EXPECT().GetIndexerSource(gomock.Any(), int64(1)).Return(model.IndexerSource{
+			ID: 1, Enabled: true,
+		}, nil)
+		factory.EXPECT().NewIndexerSource(gomock.Any()).Return(src, nil)
+		src.EXPECT().Search(gomock.Any(), int32(1), gomock.Any(), gomock.Any()).Return(want, nil)
 
 		got, err := svc.SearchIndexers(ctx, []int32{1}, nil, indexer.SearchOptions{Query: "test movie"})
 		require.NoError(t, err)
 		assert.Equal(t, want, got)
+	})
+
+	t.Run("returns partial results when one indexer in a source fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		svc, _, srcStorage, factory := newTestIndexerService(ctrl)
+
+		src := indexerMock.NewMockIndexerSource(ctrl)
+		srcStorage.EXPECT().GetIndexerSource(ctx, int64(1)).Return(model.IndexerSource{
+			ID: 1, Name: "prowlarr", Scheme: "http", Host: "host1", Enabled: true,
+		}, nil)
+		factory.EXPECT().NewIndexerSource(gomock.Any()).Return(src, nil)
+		src.EXPECT().ListIndexers(ctx).Return([]indexer.SourceIndexer{
+			{ID: 10, Name: "idx-10"},
+			{ID: 20, Name: "idx-20"},
+		}, nil)
+		require.NoError(t, svc.RefreshIndexerSource(ctx, 1))
+
+		releases := []*prowlarr.ReleaseResource{{Title: nullable.NewNullableWithValue("Movie A")}}
+		srcStorage.EXPECT().GetIndexerSource(gomock.Any(), int64(1)).Return(model.IndexerSource{
+			ID: 1, Enabled: true,
+		}, nil)
+		factory.EXPECT().NewIndexerSource(gomock.Any()).Return(src, nil)
+		// indexer 10 succeeds
+		src.EXPECT().Search(gomock.Any(), int32(10), gomock.Any(), gomock.Any()).Return(releases, nil)
+		// indexer 20 fails — searchIndexerSource logs and continues
+		src.EXPECT().Search(gomock.Any(), int32(20), gomock.Any(), gomock.Any()).Return(nil, errors.New("source unavailable"))
+
+		got, err := svc.SearchIndexers(ctx, []int32{10, 20}, nil, indexer.SearchOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, releases, got)
+	})
+
+	t.Run("does not hang when source goroutine is slow", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		svc, _, srcStorage, factory := newTestIndexerService(ctrl)
+
+		src := indexerMock.NewMockIndexerSource(ctrl)
+		srcStorage.EXPECT().GetIndexerSource(ctx, int64(1)).Return(model.IndexerSource{
+			ID: 1, Name: "prowlarr", Scheme: "http", Host: "prowlarr-host", Enabled: true,
+		}, nil)
+		factory.EXPECT().NewIndexerSource(gomock.Any()).Return(src, nil)
+		src.EXPECT().ListIndexers(ctx).Return([]indexer.SourceIndexer{{ID: 1, Name: "indexer-1"}}, nil)
+		require.NoError(t, svc.RefreshIndexerSource(ctx, 1))
+
+		// Simulate a source that blocks until its per-source context times out
+		srcStorage.EXPECT().GetIndexerSource(gomock.Any(), int64(1)).Return(model.IndexerSource{
+			ID: 1, Enabled: true,
+		}, nil)
+		factory.EXPECT().NewIndexerSource(gomock.Any()).Return(src, nil)
+		src.EXPECT().Search(gomock.Any(), int32(1), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, _ int32, _ []int32, _ indexer.SearchOptions) ([]*prowlarr.ReleaseResource, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		)
+
+		// SearchIndexers must complete within sourceSearchTimeout, not hang indefinitely
+		done := make(chan struct{})
+		go func() {
+			svc.SearchIndexers(ctx, []int32{1}, nil, indexer.SearchOptions{})
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Completed — the per-source timeout prevented a hang
+		case <-time.After(35 * time.Second):
+			t.Fatal("SearchIndexers hung — source goroutine was not cancelled by per-source timeout")
+		}
 	})
 }


### PR DESCRIPTION
## Problem

`SearchIndexers` spawns one goroutine per source but passes the raw caller context directly to `searchIndexerSource`. If any source is slow or unresponsive, the goroutine blocks indefinitely, stalling `wg.Wait()` and hanging the entire `SearchIndexers` call.

Closes #159

## Fix

- Added a `sourceSearchTimeout` constant (`30 * time.Second`)
- Inside each goroutine, create a per-source child context with `context.WithTimeout(ctx, sourceSearchTimeout)` and `defer cancel()`
- On timeout the context error propagates into `result.err`, the aggregator loop handles it, and every goroutine path (success / error / timeout) always sends to `resultChan` — no leaks

## Testing

- **Existing tests updated**: Mock expectations now use `gomock.Any()` for context since goroutines wrap it with a timeout
- **`returns partial results when one indexer in a source fails`**: Verifies that when one indexer search fails, the other's results are still returned
- **`does not hang when source goroutine is slow`**: Simulates a blocking `Search` call that waits for context cancellation, then verifies `SearchIndexers` completes within the timeout rather than hanging indefinitely

```
go test ./pkg/... ./server/... — all pass
go vet ./... — clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search operations now enforce per-source timeouts (30s), so slow/unresponsive sources are cancelled independently while still returning aggregated partial results.

* **Tests**
  * Added tests verifying partial results when some per-source searches fail and that searches do not hang when a per-source search times out.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kasuboski/mediaz/pull/171)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->