### PR TITLE
fix: validate discovered movie file paths are actually relative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ The project uses `gomock` library to avoid external dependencies during testing.
 
 **External Components**: Components that interact with the outside world have generated mocks with `gomock`. These mocks are in a `mocks` folder next to the component.
 
+**Struct Assertions**: Tests should assert on the full returned struct, not just individual fields.
+
 **Mock Setup Example**:
 ```go
 ctrl := gomock.NewController(t)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-jet/jet/v2/qrm"
@@ -86,6 +87,7 @@ func New(tmbdClient tmdb.ITmdb, indexerFactory indexer.Factory, library library.
 
 // ErrValidation is returned when request validation fails.
 var ErrValidation = errors.New("validation error")
+
 // SearchMovie queries TMDB for a movie
 func (m MediaManager) SearchMovie(ctx context.Context, query string) (*SearchMediaResponse, error) {
 	return m.movieService.SearchMovie(ctx, query)
@@ -304,9 +306,15 @@ func (m MediaManager) IndexMovieLibrary(ctx context.Context) error {
 			continue
 		}
 
+		if filepath.IsAbs(discoveredFile.RelativePath) {
+			log.Warn("discovered file has absolute path, skipping",
+				zap.String("path", discoveredFile.RelativePath))
+			continue
+		}
+
 		mf := model.MovieFile{
-			OriginalFilePath: &discoveredFile.RelativePath, // this should always be relative if we discovered it in the library.. surely
-			RelativePath:     &discoveredFile.RelativePath, // TODO: make sure it's actually relative
+			OriginalFilePath: &discoveredFile.RelativePath,
+			RelativePath:     &discoveredFile.RelativePath,
 			Size:             discoveredFile.Size,
 		}
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -267,8 +267,16 @@ func TestIndexMovieLibrary(t *testing.T) {
 
 		movieFiles, err := store.ListMovieFiles(ctx)
 		require.NoError(t, err)
-		assert.Len(t, movieFiles, 1)
-		assert.Equal(t, "Movie 2/movie2.mkv", *movieFiles[0].RelativePath)
+		require.Len(t, movieFiles, 1)
+
+		expected := model.MovieFile{
+			ID:               movieFiles[0].ID,
+			DateAdded:        movieFiles[0].DateAdded,
+			RelativePath:     ptr.To("Movie 2/movie2.mkv"),
+			OriginalFilePath: ptr.To("Movie 2/movie2.mkv"),
+			Size:             2048,
+		}
+		assert.Equal(t, expected, *movieFiles[0])
 	})
 }
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -244,6 +244,32 @@ func TestIndexMovieLibrary(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, movieFiles, 1)
 	})
+
+	t.Run("skips discovered files with absolute relative path", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		ctx := context.Background()
+
+		store := newStore(t, ctx)
+		mockLibrary := mockLibrary.NewMockLibrary(ctrl)
+
+		discoveredFiles := []library.MovieFile{
+			{RelativePath: "/absolute/path/Movie 1/movie1.mp4", AbsolutePath: "/absolute/path/Movie 1/movie1.mp4", Size: 1024},
+			{RelativePath: "Movie 2/movie2.mkv", AbsolutePath: "/movies/Movie 2/movie2.mkv", Size: 2048},
+		}
+
+		mockLibrary.EXPECT().FindMovies(ctx).Times(1).Return(discoveredFiles, nil)
+
+		m := New(nil, nil, mockLibrary, store, nil, config.Manager{}, config.Config{})
+		require.NotNil(t, m)
+
+		err := m.IndexMovieLibrary(ctx)
+		assert.NoError(t, err)
+
+		movieFiles, err := store.ListMovieFiles(ctx)
+		require.NoError(t, err)
+		assert.Len(t, movieFiles, 1)
+		assert.Equal(t, "Movie 2/movie2.mkv", *movieFiles[0].RelativePath)
+	})
 }
 
 func TestListShowsInLibrary(t *testing.T) {


### PR DESCRIPTION
## Summary

Validates that `discoveredFile.RelativePath` is actually a relative path before creating a `MovieFile`. If the path is absolute, it logs a warning and skips the file rather than storing a bad path that would break downstream resolution.

## Changes

- Add `filepath.IsAbs()` guard in `IndexMovieLibrary` before creating `MovieFile`
- Log a warning and skip files with absolute paths
- Remove the TODO comments that acknowledged the issue
- Add test: `skips discovered files with absolute relative path`

## Testing

```
go test ./pkg/manager/ -v -run TestIndexMovieLibrary
```

All tests pass including the new test case.

Closes #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path validation during movie library indexing. Files with absolute paths in relative path fields are now skipped with a warning, preventing invalid data storage and ensuring library integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kasuboski/mediaz/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->