### PR TITLE
fix: continue reconcile with partial search results

### DIFF
--- a/cmd/indexer.go
+++ b/cmd/indexer.go
@@ -134,7 +134,10 @@ var searchIndexerCmd = &cobra.Command{
 			Query: query,
 		})
 		if err != nil {
-			log.Fatalw("failed to search indexers", "error", err)
+			if len(releases) == 0 {
+				log.Fatalw("failed to search indexers", "error", err)
+			}
+			log.Warnw("some indexer sources failed", "error", err)
 		}
 
 		for _, r := range releases {

--- a/pkg/manager/indexer_service.go
+++ b/pkg/manager/indexer_service.go
@@ -458,7 +458,7 @@ func (is IndexerService) SearchIndexers(ctx context.Context, indexers, categorie
 		return nil, searchErr
 	}
 
-	return allReleases, nil
+	return allReleases, searchErr
 }
 
 func (is IndexerService) searchIndexerSource(ctx context.Context, sourceID int64, indexerIDs, categories []int32, opts indexer.SearchOptions) ([]*prowlarr.ReleaseResource, error) {

--- a/pkg/manager/indexer_service_test.go
+++ b/pkg/manager/indexer_service_test.go
@@ -775,6 +775,52 @@ func TestIndexerService_SearchIndexers(t *testing.T) {
 		assert.Equal(t, releases, got)
 	})
 
+	t.Run("returns partial results and error when one source fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		svc, _, srcStorage, factory := newTestIndexerService(ctrl)
+
+		// Source 1 with indexer 10
+		src1 := indexerMock.NewMockIndexerSource(ctrl)
+		srcStorage.EXPECT().GetIndexerSource(ctx, int64(1)).Return(model.IndexerSource{
+			ID: 1, Name: "prowlarr-1", Scheme: "http", Host: "host1", Enabled: true,
+		}, nil)
+		factory.EXPECT().NewIndexerSource(gomock.Any()).Return(src1, nil)
+		src1.EXPECT().ListIndexers(ctx).Return([]indexer.SourceIndexer{
+			{ID: 10, Name: "idx-10"},
+		}, nil)
+		require.NoError(t, svc.RefreshIndexerSource(ctx, 1))
+
+		// Source 2 with indexer 20
+		src2 := indexerMock.NewMockIndexerSource(ctrl)
+		srcStorage.EXPECT().GetIndexerSource(ctx, int64(2)).Return(model.IndexerSource{
+			ID: 2, Name: "prowlarr-2", Scheme: "http", Host: "host2", Enabled: true,
+		}, nil)
+		factory.EXPECT().NewIndexerSource(gomock.Any()).Return(src2, nil)
+		src2.EXPECT().ListIndexers(ctx).Return([]indexer.SourceIndexer{
+			{ID: 20, Name: "idx-20"},
+		}, nil)
+		require.NoError(t, svc.RefreshIndexerSource(ctx, 2))
+
+		releases := []*prowlarr.ReleaseResource{{Title: nullable.NewNullableWithValue("Movie A")}}
+
+		// Source 1 succeeds
+		srcStorage.EXPECT().GetIndexerSource(gomock.Any(), int64(1)).Return(model.IndexerSource{
+			ID: 1, Enabled: true,
+		}, nil)
+		factory.EXPECT().NewIndexerSource(gomock.Any()).Return(src1, nil)
+		src1.EXPECT().Search(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(releases, nil)
+
+		// Source 2 fails at source level (GetIndexerSource returns error)
+		srcStorage.EXPECT().GetIndexerSource(gomock.Any(), int64(2)).Return(model.IndexerSource{}, errors.New("source unavailable"))
+
+		got, err := svc.SearchIndexers(ctx, []int32{10, 20}, nil, indexer.SearchOptions{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "source unavailable")
+		assert.Equal(t, releases, got)
+	})
+
 	t.Run("does not hang when source goroutine is slow", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/pkg/manager/movie_reconcile.go
+++ b/pkg/manager/movie_reconcile.go
@@ -262,8 +262,10 @@ func (m MediaManager) reconcileMissingMovie(ctx context.Context, movie *storage.
 		Type:  ptr.To(indexer.TypeMovie),
 	})
 	if err != nil {
-		log.Debug("failed to search indexer", zap.Int32s("indexers", indexerIDs), zap.Error(err))
-		return err
+		log.Warn("some indexer sources failed during movie search", zap.Int32s("indexers", indexerIDs), zap.Error(err))
+		if len(releases) == 0 {
+			return err
+		}
 	}
 
 	availableProtocols := snapshot.GetProtocols()

--- a/pkg/manager/search.go
+++ b/pkg/manager/search.go
@@ -46,8 +46,10 @@ func (m MediaManager) executeSearch(ctx context.Context, snapshot *ReconcileSnap
 
 	releases, err := m.indexerService.SearchIndexers(ctx, indexerIDs, categories, opts)
 	if err != nil {
-		log.Error("failed to search indexers", zap.Error(err))
-		return nil, err
+		log.Warn("some indexer sources failed during search", zap.Error(err))
+		if len(releases) == 0 {
+			return nil, err
+		}
 	}
 
 	return releases, nil

--- a/pkg/manager/series_reconcile.go
+++ b/pkg/manager/series_reconcile.go
@@ -367,8 +367,10 @@ func (m MediaManager) reconcileMissingSeries(ctx context.Context, series *storag
 		Type:  ptr.To(indexer.TypeTV),
 	})
 	if err != nil {
-		log.Debug("failed to search indexer", zap.Int32s("indexers", snapshot.GetIndexerIDs()), zap.Error(err))
-		return err
+		log.Warn("some indexer sources failed during series search", zap.Int32s("indexers", snapshot.GetIndexerIDs()), zap.Error(err))
+		if len(releases) == 0 {
+			return err
+		}
 	}
 
 	slices.SortFunc(releases, sortReleaseFunc())
@@ -729,8 +731,6 @@ func (m MediaManager) updateSeasonState(ctx context.Context, id int64, state sto
 	return nil
 }
 
-
-
 // updateSeriesState updates the series state and handles cascading updates
 func (m MediaManager) updateSeriesState(ctx context.Context, id int64, state storage.SeriesState, metadata *storage.TransitionStateMetadata) error {
 	log := logger.FromCtx(ctx).With("series id", id, "to state", state)
@@ -784,8 +784,6 @@ func (m MediaManager) evaluateAndUpdateSeasonState(ctx context.Context, seasonID
 
 	return m.updateSeasonState(ctx, int64(seasonID), newSeasonState, nil)
 }
-
-
 
 // evaluateAndUpdateSeriesState evaluates all seasons in a series and updates the series state accordingly
 func (m MediaManager) evaluateAndUpdateSeriesState(ctx context.Context, seriesID int32) error {


### PR DESCRIPTION
## Summary

When `SearchIndexers` returns partial releases alongside a non-nil error, reconciliation callers now continue with the available releases (logging a warning) rather than aborting.

## Changes

- `SearchIndexers` now returns partial errors alongside releases (previously swallowed when releases existed)
- `reconcileMissingMovie`: log warning + continue with partial results, only bail if empty
- `reconcileMissingSeries`: same treatment
- New test: `returns partial results and error when one source fails`

## Testing

```
go test ./...  # all pass
```

Closes #160