### PR TITLE
ci: add codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+ignore:
+  - "pkg/storage/sqlcdb/**"
+  - "pkg/storage/sqlite/schema/gen/**"
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto


### PR DESCRIPTION
Adds a  to main so that Codecov reads config from the base branch.

- Excludes generated code (, ) from coverage
- Sets  for both project and patch checks

This is needed before the sqlc PR (#166) can pass codecov checks — Codecov reads config from the base branch, not the PR branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Codecov configuration to manage code coverage metrics, exclusion rules, and automated status check targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kasuboski/mediaz/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->