### PR TITLE
ci: fix codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,10 @@
-ignore:
-  - "pkg/storage/sqlcdb/**"
-  - "pkg/storage/sqlite/schema/gen/**"
-
 coverage:
   status:
     project:
       default:
         target: auto
-    patch:
-      default:
-        target: auto
+        threshold: 1%
+    patch: off
+ignore:
+  - "pkg/storage/sqlcdb/**"
+  - "pkg/storage/sqlite/schema/gen/**"


### PR DESCRIPTION
Two changes to the codecov config:

- **Disable patch check** (`patch: off`) — patch coverage is meaningless when PRs add generated code (sqlc). It measures coverage of diff lines only, so generated files tank it regardless of `ignore`.
- **Allow 1% project threshold** — `target: auto` with a 1% tolerance so small drops don't fail CI.

This should unblock PR #166 (sqlc init).